### PR TITLE
Fix gcc/glibc build errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,6 +92,7 @@ set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 
 option(WITH_LIBPNG_SOURCE "Compile libpng from source" ON)
 
+add_compile_options(-D_DEFAULT_SOURCE -std=c99)
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 add_subdirectory(util)
 include_directories(util)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,7 +92,7 @@ set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 
 option(WITH_LIBPNG_SOURCE "Compile libpng from source" ON)
 
-add_compile_options(-D_DEFAULT_SOURCE -std=c99)
+add_compile_options(-D_GNU_SOURCE -std=c99)
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 add_subdirectory(util)
 include_directories(util)

--- a/thtk/util.h
+++ b/thtk/util.h
@@ -30,7 +30,6 @@
 #define UTIL_H_
 
 #include <config.h>
-#define _GNU_SOURCE
 #include <string.h>
 
 #ifndef HAVE_MEMPCPY


### PR DESCRIPTION
When `_GNU_SOURCE` is not defined, some functions used in util/util.c aren't defined. Without `-std=c99` gcc complains about using for loop initial declarations.