### PR TITLE
Added support for mnemonic mappings

### DIFF
--- a/thecl/CMakeLists.txt
+++ b/thecl/CMakeLists.txt
@@ -5,8 +5,8 @@ flex_target(EcsScan ecsscan.l ${CMAKE_CURRENT_BINARY_DIR}/ecsscan.c)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR})
 add_executable(thecl
   ${BISON_EcsParse_OUTPUT_SOURCE} ${FLEX_EcsScan_OUTPUTS}
-  expr.c thecl.c thecl06.c thecl10.c
-  expr.h thecl.h)
+  expr.c thecl.c eclmap.c thecl06.c thecl10.c
+  expr.h thecl.h eclmap.h)
 target_link_libraries(thecl util)
 install(TARGETS thecl DESTINATION bin)
 install(FILES thecl.1 DESTINATION share/man/man1)

--- a/thecl/eclmap.c
+++ b/thecl/eclmap.c
@@ -230,6 +230,9 @@ eclmap_load(
                 fprintf(stderr, "%s:%s:%u: '%s' isn't valid identifier\n",argv0,fn,linecount,ent.mnemonic);
                 continue;
             }
+            if(!strncmp(ent.mnemonic, "ins_", 4)) {
+                fprintf(stderr, "%s:%s:%u: mnemonic can't start with 'ins_'\n",argv0,fn,linecount);
+            }
         }
 
         eclmap_set(map, &ent);

--- a/thecl/eclmap.c
+++ b/thecl/eclmap.c
@@ -1,0 +1,207 @@
+/*
+ * Redistribution and use in source and binary forms, with
+ * or without modification, are permitted provided that the
+ * following conditions are met:
+ *
+ * 1. Redistributions of source code must retain this list
+ *    of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce this
+ *    list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the
+ *    distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ * CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+ * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+#include <config.h>
+#include <stddef.h>
+#include <string.h>
+#include <stdlib.h>
+#include <errno.h>
+#include "eclmap.h"
+#include "program.h"
+
+static void
+eclmap_dump(
+    eclmap_t* map)
+{
+    eclmap_entry_t* ent;
+    list_for_each(map, ent) {
+        printf("%d %s %s\n",
+            ent->opcode,
+            ent->signature ? ent->signature : "?",
+            ent->mnemonic ? ent->mnemonic : "?");
+    }
+}
+
+void
+eclmap_free(
+    eclmap_t* map)
+{
+    eclmap_entry_t* ent;
+
+    if(!map) return;
+
+    list_for_each(map, ent) {
+        if(ent) {
+            free(ent->signature);
+            free(ent->mnemonic);
+        }
+        free(ent);
+    }
+
+    list_free_nodes(map);
+
+    free(map);
+}
+
+/* Allocates new eclmap entry, appends it to a eclmap, and returns it */
+static eclmap_entry_t*
+eclmap_append_new(
+    eclmap_t* map,
+    int opcode)
+{
+    eclmap_entry_t* ent = malloc(sizeof(eclmap_entry_t));
+    ent->opcode = opcode;
+    ent->signature = NULL;
+    ent->mnemonic = NULL;
+    list_append_new(map, ent);
+    return ent;
+}
+
+void
+eclmap_set(
+    eclmap_t* map,
+    const eclmap_entry_t* ent1)
+{
+    eclmap_entry_t* ent2;
+    list_for_each(map, ent2) {
+        if(ent2 && ent2->opcode == ent1->opcode) {
+            break;
+        }
+    }
+
+    if(!ent2) {
+        ent2 = eclmap_append_new(map, ent1->opcode);
+    }
+
+    if(ent1->signature) {
+        free(ent2->signature);
+        ent2->signature = strdup(ent1->signature);
+    }
+
+    if(ent1->mnemonic) {
+        free(ent2->mnemonic);
+        ent2->mnemonic = strdup(ent1->mnemonic);
+    }
+}
+
+eclmap_entry_t*
+eclmap_get(
+    eclmap_t* map,
+    int opcode)
+{
+    eclmap_entry_t* ent;
+    list_for_each(map, ent) {
+        if(ent && ent->opcode == opcode) {
+            break;
+        }
+    }
+
+    if(!ent) {
+        ent = eclmap_append_new(map, opcode);
+    }
+
+    return ent;
+}
+
+eclmap_entry_t*
+eclmap_find(
+    eclmap_t* map,
+    const char* mnemonic)
+{
+    eclmap_entry_t* ent;
+    list_for_each(map, ent) {
+        if(ent && ent->mnemonic && !strcmp(ent->mnemonic, mnemonic)) {
+            break;
+        }
+    }
+    return ent;
+}
+
+void
+eclmap_load(
+    eclmap_t* map,
+    FILE* f,
+    const char* fn)
+{
+    static char buffer[512];
+
+    /* TODO: maybe do proper parsing with lex/yacc? */
+
+    if(!fgets(buffer, sizeof(buffer), f)) {
+        fprintf(stderr, "%s:%s: couldn't read the first line\n",argv0,fn);
+        return;
+    }
+
+    if(strncmp(buffer, "eclmap", 6)) {
+        fprintf(stderr, "%s:%s:1: invalid magic\n",argv0,fn);
+        return;
+    }
+
+    int linecount = 1;
+    while(fgets(buffer, sizeof(buffer), f)) {
+        char *ptr, *ptrend;
+        eclmap_entry_t ent;
+
+        ++linecount;
+
+        /* remove the comments */
+        ptr = strchr(buffer, '#');
+        if(ptr) *ptr = '\0';
+
+        /* parse opcode */
+        ptr = strtok(buffer, " \t\r\n");
+        if(!ptr) continue; /* 0 tokens -> empty line, no need to error */
+
+        errno = 0;
+        ent.opcode = strtol(ptr, &ptrend, 0);
+        if(ptr == ptrend || errno != 0) {
+            fprintf(stderr, "%s:%s:%u: opcode token is not a number\n",argv0,fn,linecount);
+            continue;
+        }
+
+        /* parse signature */
+        ptr = strtok(NULL, " \t\r\n");
+        if(!ptr) {
+            fprintf(stderr, "%s:%s:%u: not enough tokens\n",argv0,fn,linecount);
+            continue;
+        }
+        /* TODO: validate signature */
+        ent.signature = ptr[0] == '?' ? NULL : ptr;
+
+        /* parse mnemonic */
+        ptr = strtok(NULL, " \t\r\n");
+        if(!ptr) {
+            fprintf(stderr, "%s:%s:%u: not enough tokens\n",argv0,fn,linecount);
+        }
+        /* TODO: validate mnemonic */
+        ent.mnemonic = ptr[0] == '?' ? NULL : ptr;
+
+        eclmap_set(map, &ent);
+    }
+}

--- a/thecl/eclmap.c
+++ b/thecl/eclmap.c
@@ -191,16 +191,46 @@ eclmap_load(
             fprintf(stderr, "%s:%s:%u: not enough tokens\n",argv0,fn,linecount);
             continue;
         }
-        /* TODO: validate signature */
-        ent.signature = ptr[0] == '?' ? NULL : ptr;
+
+        /* validate signature */
+        if(ptr[0] == '?') {
+            ent.signature = NULL;
+        }
+        else {
+            ent.signature = ptr;
+            if(ptr[0] == '_') ptr[0] = '\0'; /* allow empty strings to be specified with "_" */
+            /* TODO: validate signature */
+            fprintf(stderr, "%s:%s:%u: warning: signature mapping is not yet implemented\n",argv0,fn,linecount);
+        }
 
         /* parse mnemonic */
         ptr = strtok(NULL, " \t\r\n");
         if(!ptr) {
             fprintf(stderr, "%s:%s:%u: not enough tokens\n",argv0,fn,linecount);
+            continue;
         }
-        /* TODO: validate mnemonic */
-        ent.mnemonic = ptr[0] == '?' ? NULL : ptr;
+
+        /* validate mnemonic */
+        if(ptr[0] == '?') {
+            ent.mnemonic = NULL;
+        }
+        else {
+            ent.mnemonic = ptr;
+            if(ptr[0] >= '0' && ptr[0] <= '9') { /* first character must not be digit */
+                fprintf(stderr, "%s:%s:%u: '%s' isn't valid identifier\n",argv0,fn,linecount,ent.mnemonic);
+                continue;
+            }
+            while(*ptr) {
+                if(!(*ptr >= '0' && *ptr <='9' || *ptr >= 'a' && *ptr <= 'z' || *ptr >= 'A' && *ptr <= 'Z' || *ptr == '_')) {
+                    break;
+                }
+                ptr++;
+            }
+            if(*ptr) {
+                fprintf(stderr, "%s:%s:%u: '%s' isn't valid identifier\n",argv0,fn,linecount,ent.mnemonic);
+                continue;
+            }
+        }
 
         eclmap_set(map, &ent);
     }

--- a/thecl/eclmap.h
+++ b/thecl/eclmap.h
@@ -1,0 +1,59 @@
+/*
+ * Redistribution and use in source and binary forms, with
+ * or without modification, are permitted provided that the
+ * following conditions are met:
+ *
+ * 1. Redistributions of source code must retain this list
+ *    of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce this
+ *    list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the
+ *    distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ * CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+ * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+#ifndef ECLMAP_H_
+#define ECLMAP_H_
+
+#include <config.h>
+#include <stddef.h>
+#include <stdio.h>
+#include "list.h"
+
+typedef struct eclmap_entry_t {
+    int opcode;
+    char* signature;
+    char* mnemonic;
+} eclmap_entry_t;
+
+typedef list_t eclmap_t;
+
+/* Allocates and initalizes a new eclmap */
+#define eclmap_new() ((eclmap_t*)list_new())
+/* Frees an eclmap */
+void eclmap_free(eclmap_t* map);
+/* Sets an entry in a eclmap */
+void eclmap_set(eclmap_t* map, const eclmap_entry_t* ent);
+/* Finds an entry in a eclmap by opcode */
+eclmap_entry_t* eclmap_get(eclmap_t* map, int opcode);
+/* Finds an entry in a eclmap by mnemonic */
+eclmap_entry_t* eclmap_find(eclmap_t* map, const char* mnemonic);
+/* Loads entries from eclmap file (thread unsafe) */
+void eclmap_load(eclmap_t* map, FILE* f, const char* fn);
+
+#endif

--- a/thecl/ecsparse.y
+++ b/thecl/ecsparse.y
@@ -368,7 +368,25 @@ Instructions:
     /* TODO: Check the given parameters against the parameters expected for the
      *       instruction. */
 Instruction:
-      INSTRUCTION "(" Instruction_Parameters ")" {
+      IDENTIFIER "(" Instruction_Parameters ")" {
+        expression_t* expr;
+        list_for_each(&state->expressions, expr) {
+            expression_output(state, expr);
+            expression_free(expr);
+        }
+        list_free_nodes(&state->expressions);
+
+        eclmap_entry_t* ent = eclmap_find(g_eclmap, $1);
+        if(!ent) {
+            yyerror(state, "unknown mnemonic");
+        }
+        else {
+            instr_add(state->current_sub, instr_new_list(state, ent->opcode, $3));
+        }
+
+        free($3);
+      }
+    | INSTRUCTION "(" Instruction_Parameters ")" {
         expression_t* expr;
         list_for_each(&state->expressions, expr) {
             expression_output(state, expr);

--- a/thecl/thecl.c
+++ b/thecl/thecl.c
@@ -164,13 +164,14 @@ param_free(
 static void
 print_usage(void)
 {
-    printf("Usage: %s COMMAND[OPTION...] [INPUT [OUTPUT]]\n"
+    printf("Usage: %s COMMAND[OPTION...] [MAPFILE] [INPUT [OUTPUT]]\n"
            "COMMAND can be:\n"
            "  c  create ECL file\n"
            "  d  dump ECL file\n"
            "  V  display version information and exit\n"
            "OPTION can be:\n"
            "  #  # can be 6, 7, 8, 9, 95, 10, 103 (for Uwabami Breakers), 11, 12, 125, 128, 13, 14, 143, or 15 (required)\n"
+           "  m  use map file for translating mnemonics\n"
            "Report bugs to <" PACKAGE_BUGREPORT ">.\n", argv0);
 }
 

--- a/thecl/thecl.c
+++ b/thecl/thecl.c
@@ -226,9 +226,10 @@ main(int argc, char* argv[])
     {
     case 'c':
     case 'd': {
+        g_eclmap = eclmap_new();
+
         int argp = 2;
         if(!strchr(options, 'm')) {
-            g_eclmap = eclmap_new();
             if(argc > argp) {
                 FILE* map_file = NULL;
                 map_file = fopen(argv[argp], "r");

--- a/thecl/thecl.c
+++ b/thecl/thecl.c
@@ -38,6 +38,8 @@
 extern const thecl_module_t th06_ecl;
 extern const thecl_module_t th10_ecl;
 
+eclmap_t* g_eclmap = NULL;
+
 thecl_t*
 thecl_new(
     void)
@@ -180,11 +182,12 @@ main(int argc, char* argv[])
     unsigned int version = 0;
     int mode;
     const thecl_module_t* module = NULL;
+    char options[] = "m";
 
     current_input = "(stdin)";
     current_output = "(stdout)";
 
-    mode = parse_args(argc, argv, print_usage, "cdV", "", &version);
+    mode = parse_args(argc, argv, print_usage, "cdV", options, &version);
 
     if (!mode)
         exit(1);
@@ -223,20 +226,43 @@ main(int argc, char* argv[])
     {
     case 'c':
     case 'd': {
-        if (argc > 2) {
-            current_input = argv[2];
-            in = fopen(argv[2], "rb");
-            if (!in) {
-                fprintf(stderr, "%s: couldn't open %s for reading: %s\n",
-                    argv0, argv[2], strerror(errno));
+        int argp = 2;
+        if(!strchr(options, 'm')) {
+            g_eclmap = eclmap_new();
+            if(argc > argp) {
+                FILE* map_file = NULL;
+                map_file = fopen(argv[argp], "r");
+                if (!map_file) {
+                    fprintf(stderr, "%s: couldn't open %s for reading: %s\n",
+                        argv0, argv[argp], strerror(errno));
+                    exit(1);
+                }
+                eclmap_load(g_eclmap, map_file, argv[argp]);
+                fclose(map_file);
+            }
+            else {
+                fprintf(stderr, "%s: missing map filename\n",
+                    argv0);
                 exit(1);
             }
-            if (argc > 3) {
-                current_output = argv[3];
-                out = fopen(argv[3], "wb");
+            ++argp;
+        }
+
+        if (argc > argp) {
+            current_input = argv[argp];
+            in = fopen(argv[argp], "rb");
+            if (!in) {
+                fprintf(stderr, "%s: couldn't open %s for reading: %s\n",
+                    argv0, argv[argp], strerror(errno));
+                exit(1);
+            }
+            ++argp;
+            if (argc > argp) {
+                current_output = argv[argp];
+                out = fopen(argv[argp], "wb");
                 if (!out) {
                     fprintf(stderr, "%s: couldn't open %s for writing: %s\n",
-                        argv0, argv[3], strerror(errno));
+                        argv0, argv[argp], strerror(errno));
                     fclose(in);
                     exit(1);
                 }
@@ -259,6 +285,7 @@ main(int argc, char* argv[])
         }
         fclose(in);
         fclose(out);
+        eclmap_free(g_eclmap);
 
         exit(0);
     }

--- a/thecl/thecl.h
+++ b/thecl/thecl.h
@@ -33,6 +33,7 @@
 #include <stdio.h>
 #include "list.h"
 #include "value.h"
+#include "eclmap.h"
 
 typedef enum {
     THECL_INSTR_INSTR,
@@ -166,5 +167,7 @@ typedef struct {
 
 extern FILE* yyin;
 extern int yyparse(parser_state_t*);
+
+extern eclmap_t* g_eclmap;
 
 #endif

--- a/thecl/thecl06.c
+++ b/thecl/thecl06.c
@@ -840,7 +840,13 @@ th06_dump(
                     !((instr->rank) & RANK_UNKNOWN4) ? "Z" : "");
                 break;
             case THECL_INSTR_INSTR: {
-                fprintf(out, "    ins_%u(", instr->id);
+                eclmap_entry_t *ent = eclmap_get(g_eclmap, instr->id);
+                if(ent->mnemonic) {
+                    fprintf(out, "    %s(", ent->mnemonic);
+                }
+                else {
+                    fprintf(out, "    ins_%u(", instr->id);
+                }
                 thecl_param_t* param;
                 int first = 1;
                 list_for_each(&instr->params, param) {

--- a/thecl/thecl10.c
+++ b/thecl/thecl10.c
@@ -1420,7 +1420,14 @@ th10_stringify_instr(
     if (instr->type != THECL_INSTR_INSTR)
         return;
 
-    sprintf(string, "ins_%u(", instr->id);
+    eclmap_entry_t *ent = eclmap_get(g_eclmap, instr->id);
+    if(ent->mnemonic) {
+        sprintf(string, "%s(", ent->mnemonic);
+    }
+    else {
+        sprintf(string, "ins_%u(", instr->id);
+    }
+
     for (p = 0; p < instr->param_count; ++p) {
         size_t removed = 0;
         char* param_string = th10_stringify_param(sub, node, p, NULL, &removed, 0);


### PR DESCRIPTION
This PR adds support for "eclmaps", simple format that I came up with. Here's an example of usage:
```$ thecl -d6m my_th6.map  ecldata1.ecl ecldata1.ecs ```
will decode ecldata1 and translate the instructions to mnemonics using mappings my_th6.map.

First line is "eclmap" (signature), all the other lines are entries:
```<opcode> <signature> <mnemonic>```

1) Opcode is obviously the opcode.
2) Signature is supposed to be the format of the arguments. Right now it's unimplemented.
3) Mnemonic is the mnemonic that the opcode will be translated to/from.

Example:
```0 ? noop```

The question mark means empty field. (Later you will be able to load multiple mappings and combine them into one.)

Here are some example eclmaps:

[map for th06](https://pastebin.com/raw/y0JA8yYp) ([source](https://pytouhou.linkmauve.fr/doc/06/msg.xml))
[map for th13](https://pastebin.com/raw/6qdr9fFd) ([source](http://nutzer.bplaced.net/Database/thecl.json))

fixes #12
