### PR TITLE
Add missing `#ifdef __cplusplus` in dat.h

### DIFF
--- a/thtk/dat.h
+++ b/thtk/dat.h
@@ -39,6 +39,10 @@
 #define API_SYMBOL /* */
 #endif
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef struct thdat_t thdat_t;
 
 /* Opens an existing archive file read from the input stream.  The stream has


### PR DESCRIPTION
Find this issue when using `thtk` inside a c++ project. This PR simply add the missing code in `dat.h` .

Refer to [thtk/thtk/dat.h(L145)](https://github.com/thpatch/thtk/blob/e5a5e29aff46473b76f425d0b59af2a4e1fec6e1/thtk/dat.h#L145) , it seems we only have a single unpaired `}` if we are using c++.

What added:

``` cpp
#ifdef __cplusplus
extern "C" {
#endif
```

Thanks
BLumia