### PR TITLE
Better argument parsing

### DIFF
--- a/thanm/thanm.1
+++ b/thanm/thanm.1
@@ -24,45 +24,47 @@
 .\" OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 .\" SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
 .\" DAMAGE.
-.Dd March 13, 2011
+.Dd March 16, 2018
 .Dt THANM 1
 .Os thtk
 .Sh NAME
 .Nm thanm
 .Nd Touhou sprite archive tool
 .Sh SYNOPSIS
-.Nm Ar command Ns Oo option Oc Op Ar archive Op Ar ...
+.Nm
+.Op Fl Vf
+.Op Fl l | x | r | c
+.Op Ar archive Op Ar ...
 .Sh DESCRIPTION
 The
 .Nm
 utility performs various actions on sprite archives.
 The following commands are available:
-.\" TODO: List commands and write descriptions.
 .Bl -tag -width Ds
-.It Ar l Ns Oo f Oc Ar archive
+.It Nm Fl l Oo Fl f Oc Ar archive
 Displays a specification of the archive.
-.It Ar x Ns Oo f Oc Ar archive Op Ar
+.It Nm Fl x Oo Fl f Oc Ar archive Op Ar
 Extracts image files.
 If no files are specified, all files are extracted.
-.It Ar r Ns Oo f Oc Ar archive Ar name Ar file
+.It Nm Fl r Oo Fl f Oc Ar archive Ar name Ar file
 Replaces an entry in the archive.
 The name can be obtained by the
-.Ar l
+.Fl l
 command.
-.It Ar c Ns Oo f Oc Ar archive Ar input
+.It Nm Fl c Oo Fl f Oc Ar archive Ar input
 Creates a new archive from a specification obtained by the
-.Ar l
+.Fl l
 command.
 It will look for referenced image files in the current directory.
-.It Ar V
+.It Nm Fl V
 Displays the program version.
 .El
 .Pp
 These options are accepted:
 .Bl -tag -width Ds
-.It Ar f
+.It Fl f
 The
-.Ar f
+.Fl f
 option can be used to ignore certain errors.
 .El
 .Sh EXIT STATUS

--- a/thanm/thanm.c
+++ b/thanm/thanm.c
@@ -1271,7 +1271,7 @@ main(
     int i;
 #endif
 
-    argv0 = argv[0];
+    argv0 = util_shortname(argv[0]);
     int opt;
     int ind=0;
     while(argv[util_optind]) {

--- a/thanm/thanm.c
+++ b/thanm/thanm.c
@@ -1234,17 +1234,21 @@ anm_free(
 static void
 print_usage(void)
 {
-    printf("Usage: %s COMMAND\n"
-           "COMMAND can be:\n"
-           "  l[OPTION...] ARCHIVE            list archive\n", argv0);
 #ifdef HAVE_LIBPNG
-    printf("  x[OPTION...] ARCHIVE [FILE...]  extract entries\n"
-           "  r[OPTION...] ARCHIVE NAME FILE  replace entry in archive\n"
-           "  c[OPTION...] ARCHIVE SPEC       create archive\n");
+#define USAGE_LIBPNGFLAGS " | -x | -r | -c"
+#else
+#define USAGE_LIBPNGFLAGS ""
 #endif
-    printf("  V                               display version information and exit\n"
-           "OPTION can be:\n"
-           "  f  ignore errors when possible\n"
+    printf("Usage: %s [-Vf] [-l" USAGE_LIBPNGFLAGS "] ARCHIVE ...\n"
+           "Options:\n"
+           "  -l ARCHIVE            list archive\n", argv0);
+#ifdef HAVE_LIBPNG
+    printf("  -x ARCHIVE [FILE...]  extract entries\n"
+           "  -r ARCHIVE NAME FILE  replace entry in archive\n"
+           "  -c ARCHIVE SPEC       create archive\n");
+#endif
+    printf("  -V                    display version information and exit\n"
+           "  -f                    ignore errors when possible\n"
            "Report bugs to <" PACKAGE_BUGREPORT ">.\n");
 }
 

--- a/thanm/thanm.c
+++ b/thanm/thanm.c
@@ -1272,13 +1272,10 @@ main(
 #endif
 
     argv0 = argv[0];
-    char opt;
+    int opt;
     int ind=0;
     while(argv[util_optind]) {
         switch(opt = util_getopt(argc,argv,commands)) {
-        case 'V':
-            util_print_version();
-            exit(0);
         case 'l':
         case 'x':
         case 'r':
@@ -1293,20 +1290,8 @@ main(
         case 'f':
             option_force = 1;
             break;
-        case '?':
-            fprintf(stderr,"%s: Unknown option '%c'\n",argv0,util_optopt);
-            print_usage();
-            exit(1);
-        case -1:
-            if(!strcmp(argv[util_optind-1], "--")) {
-                while(argv[util_optind]) {
-                    argv[ind++] = argv[util_optind++];
-                }
-            }
-            else {
-                argv[ind++] = argv[util_optind++];
-            }
-            break;
+        default:
+            util_getopt_default(&ind,argv,opt,print_usage);
         }
     }
     argc = ind;

--- a/thdat/thdat.1
+++ b/thdat/thdat.1
@@ -55,7 +55,6 @@ Displays the program version.
 .Pp
 The version specifies which archive format to use.
 Running the program without a command will list the supported formats.
-The greatest version number is used by default.
 .Sh ENVIRONMENT
 .Bl -tag -width OMP_NUM_THREADS
 .It Ev OMP_NUM_THREADS

--- a/thdat/thdat.1
+++ b/thdat/thdat.1
@@ -24,7 +24,7 @@
 .\" OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 .\" SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
 .\" DAMAGE.
-.Dd March 13, 2011
+.Dd March 16, 2018
 .Dt THDAT 1
 .Os thtk
 .Sh NAME
@@ -32,7 +32,8 @@
 .Nd Touhou archive tool
 .Sh SYNOPSIS
 .Nm
-.Ar command Ns Op Ar version
+.Op Fl V
+.Op Oo Fl c | l | x Oc Ar version
 .Op Ar archive Op Ar
 .Sh DESCRIPTION
 The
@@ -40,15 +41,15 @@ The
 utility extracts files from an archive or creates a new archive from a set of files.
 The following commands are available:
 .Bl -tag -width Ds
-.It Ar c Ns Oo Ar version Oc Ar archive Ar file Op Ar
+.It Nm Fl c Ar version Ar archive Ar file Op Ar
 Archives the specified files.
-.It Ar l Ns Oo Ar version Oc Ar archive
+.It Nm Fl l Ar version Ar archive
 Lists the contents of the archive.
-.It Ar x Ns Oo Ar version Oc Ar archive Op Ar
+.It Nm Fl x Ar version Ar archive Op Ar
 Extracts files.
 If no files are specified, all files are extracted.
 The format is not automatically detected.
-.It Ar V
+.It Nm Fl V
 Displays the program version.
 .El
 .Pp
@@ -70,17 +71,17 @@ utility exits with 0 on success, 1 on error.
 .Sh EXAMPLES
 Create a new archive from the input files:
 .Bd -literal -offset indent
-thdat c6 output.dat input.anm input.msg input.ecl
+thdat -c6 output.dat input.anm input.msg input.ecl
 .Ed
 .Pp
 Lists the contents of the specified archive:
 .Bd -literal -offset indent
-thdat l128 th128.dat
+thdat -l128 th128.dat
 .Ed
 .Pp
 Extract all files from the archive to the current working directory:
 .Bd -literal -offset indent
-thdat x8 th08.dat
+thdat -x8 th08.dat
 .Ed
 .Sh SEE ALSO
 .Lk https://github.com/thpatch/thtk "Project homepage"

--- a/thdat/thdat.c
+++ b/thdat/thdat.c
@@ -326,7 +326,7 @@ main(
     unsigned int version = 16;
     int mode = -1;
 
-    argv0 = argv[0];
+    argv0 = util_shortname(argv[0]);
     int opt;
     int ind=0;
     while(argv[util_optind]) {

--- a/thdat/thdat.c
+++ b/thdat/thdat.c
@@ -39,14 +39,14 @@ static void
 print_usage(
     void)
 {
-    printf("Usage: %s COMMAND[OPTION...] [ARCHIVE [FILE...]]\n"
-           "COMMAND can be:\n"
-           "  c  create an archive\n"
-           "  l  list the contents of an archive\n"
-           "  x  extract an archive\n"
-           "  V  display version information and exit\n"
-           "OPTION can be:\n"
-           "  #  # can be 1, 2, 3, 4, 5, 6, 7, 8, 9, 95, 10, 103 (for Uwabami Breakers), 105, 11, 12, 123, 125, 128, 13, 14, 143, 15, or 16 defaults to the latest\n\n"
+    printf("Usage: %s [-V] [[-c | -l | -x] VERSION] [ARCHIVE [FILE...]]\n"
+           "Options:\n"
+           "  -c  create an archive\n"
+           "  -l  list the contents of an archive\n"
+           "  -x  extract an archive\n"
+           "  -V  display version information and exit\n"
+           "VERSION can be:\n"
+           "  1, 2, 3, 4, 5, 6, 7, 8, 9, 95, 10, 103 (for Uwabami Breakers), 105, 11, 12, 123, 125, 128, 13, 14, 143, 15, or 16\n\n"
            "Report bugs to <" PACKAGE_BUGREPORT ">.\n", argv0);
 }
 

--- a/thdat/thdat.c
+++ b/thdat/thdat.c
@@ -327,13 +327,10 @@ main(
     int mode = -1;
 
     argv0 = argv[0];
-    char opt;
+    int opt;
     int ind=0;
     while(argv[util_optind]) {
         switch(opt = util_getopt(argc, argv, ":c:l:x:Vd")) {
-        case 'V':
-            util_print_version();
-            exit(0);
         case 'c':
         case 'l':
         case 'x':
@@ -354,20 +351,8 @@ main(
             }
             mode = util_optopt;
             break;
-        case '?':
-            fprintf(stderr,"%s: Unknown option '%c'\n",argv0,util_optopt);
-            print_usage();
-            exit(1);
-        case -1:
-            if(!strcmp(argv[util_optind-1], "--")) {
-                while(argv[util_optind]) {
-                    argv[ind++] = argv[util_optind++];
-                }
-            }
-            else {
-                argv[ind++] = argv[util_optind++];
-            }
-            break;
+        default:
+            util_getopt_default(&ind,argv,opt,print_usage);
         }
     }
     argc = ind;

--- a/thecl/thecl.1
+++ b/thecl/thecl.1
@@ -24,7 +24,7 @@
 .\" OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 .\" SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
 .\" DAMAGE.
-.Dd August 14, 2017
+.Dd March 16, 2018
 .Dt THECL 1
 .Os thtk
 .Sh NAME
@@ -32,7 +32,9 @@
 .Nd Touhou level script tool
 .Sh SYNOPSIS
 .Nm
-.Ar command Ns Ar #
+.Op Fl Vr
+.Op Oo Fl c | d Oc Ar version
+.Oo Fl m Ar eclmap Oc Ns Ar ...
 .Op Ar input Op Ar output
 .Sh DESCRIPTION
 The
@@ -40,24 +42,24 @@ The
 utility extracts files from an archive or creates a new archive from a set of files.
 The following commands are available:
 .Bl -tag -width Ds
-.It Ar c Ns Ar # Ns Oo Ar m Ar map Oc Op Ar input Op Ar output
+.It Nm Fl c Ar version Oo Fl m Ar eclmap Oc Ns Ar ... Op Ar input Op Ar output
 Compiles a level script.
-.It Ar d Ns Ar # Ns Oo Ar r Oc Ns Oo Ar m Ar map Oc Op Ar input Op Ar output
+.It Nm Fl d Ar version Oo Fl r Oc Oo Fl m Ar eclmap Oc Ns Ar ... Op Ar input Op Ar output
 Dumps a level script.
-.It Ar V
+.It Fl V
 Displays the program version.
 .El
 .Pp
 These options are accepted:
 .Bl -tag -width Ds
-.It Ar m Ar map
+.It Fl m Ar eclmap
 The
-.Ar m
+.Fl m
 option can be used to map ins_* to human readable names.
 .\"TODO: Document eclmap format.
-.It Ar r
+.It Fl r
 The
-.Ar r
+.Fl r
 option suppresses code transformations like parameter detection, or expression decompilation.
 .El
 .Pp

--- a/thecl/thecl.1
+++ b/thecl/thecl.1
@@ -39,7 +39,7 @@
 .Sh DESCRIPTION
 The
 .Nm
-utility extracts files from an archive or creates a new archive from a set of files.
+utility (de)compiles ecl scripts.
 The following commands are available:
 .Bl -tag -width Ds
 .It Nm Fl c Ar version Oo Fl m Ar eclmap Oc Ns Ar ... Op Ar input Op Ar output

--- a/thecl/thecl.c
+++ b/thecl/thecl.c
@@ -203,7 +203,7 @@ main(int argc, char* argv[])
     g_eclmap_global = eclmap_new();
     atexit(free_eclmaps);
 
-    argv0 = argv[0];
+    argv0 = util_shortname(argv[0]);
     int opt;
     int ind=0;
     while(argv[util_optind]) {

--- a/thecl/thecl.c
+++ b/thecl/thecl.c
@@ -175,15 +175,15 @@ free_eclmaps(void)
 static void
 print_usage(void)
 {
-    printf("Usage: %s COMMAND[OPTION...] [MAPFILE] [INPUT [OUTPUT]]\n"
-           "COMMAND can be:\n"
-           "  c  create ECL file\n"
-           "  d  dump ECL file\n"
-           "  V  display version information and exit\n"
-           "OPTION can be:\n"
-           "  #  # can be 6, 7, 8, 9, 95, 10, 103 (for Uwabami Breakers), 11, 12, 125, 128, 13, 14, 143, 15, or 16 (required)\n"
-           "  m  use map file for translating mnemonics\n"
-           "  r  output raw ECL opcodes, applying minimal transformations\n"
+    printf("Usage: %s [-Vr] [[-c | -d] VERSION] [-m ECLMAP]... [INPUT [OUTPUT]]\n"
+           "Options:\n"
+           "  -c  create ECL file\n"
+           "  -d  dump ECL file\n"
+           "  -V  display version information and exit\n"
+           "  -m  use map file for translating mnemonics\n"
+           "  -r  output raw ECL opcodes, applying minimal transformations\n"
+           "VERSION can be:\n"
+           "  6, 7, 8, 9, 95, 10, 103 (for Uwabami Breakers), 11, 12, 125, 128, 13, 14, 143, 15, or 16\n"
            "Report bugs to <" PACKAGE_BUGREPORT ">.\n", argv0);
 }
 

--- a/thecl/thecl.c
+++ b/thecl/thecl.c
@@ -34,6 +34,7 @@
 #include "program.h"
 #include "thecl.h"
 #include "util.h"
+#include "mygetopt.h"
 
 extern const thecl_module_t th06_ecl;
 extern const thecl_module_t th10_ecl;
@@ -165,6 +166,13 @@ param_free(
 }
 
 static void
+free_eclmaps(void)
+{
+    eclmap_free(g_eclmap_opcode);
+    eclmap_free(g_eclmap_global);
+}
+
+static void
 print_usage(void)
 {
     printf("Usage: %s COMMAND[OPTION...] [MAPFILE] [INPUT [OUTPUT]]\n"
@@ -185,17 +193,80 @@ main(int argc, char* argv[])
     FILE* in = stdin;
     FILE* out = stdout;
     unsigned int version = 0;
-    int mode;
+    int mode = -1;
     const thecl_module_t* module = NULL;
-    char options[] = "mr";
 
     current_input = "(stdin)";
     current_output = "(stdout)";
 
-    mode = parse_args(argc, argv, print_usage, "cdV", options, &version);
+    g_eclmap_opcode = eclmap_new();
+    g_eclmap_global = eclmap_new();
+    atexit(free_eclmaps);
 
-    if (!mode)
-        exit(1);
+    argv0 = argv[0];
+    char opt;
+    int ind=0;
+    while(argv[util_optind]) {
+        switch(opt = util_getopt(argc, argv, ":c:d:Vm:r")) {
+        case 'V':
+            util_print_version();
+            exit(0);
+        case 'c':
+        case 'd':
+            if(mode != -1) {
+                fprintf(stderr,"%s: More than one mode specified\n", argv0);
+                print_usage();
+                exit(1);
+            }
+            mode = opt;
+            version = atoi(util_optarg);
+            break;
+        case ':':
+            if(util_optopt == 'm') {
+                fprintf(stderr,"%s: Missing required argument for option '%c'\n",argv0,util_optopt);
+                print_usage();
+                exit(1);
+            }
+            if(mode != -1) {
+                fprintf(stderr,"%s: More than one mode specified\n", argv0);
+                print_usage();
+                exit(1);
+            }
+            mode = util_optopt;
+            break;
+        case 'm': {
+            FILE* map_file = NULL;
+            map_file = fopen(util_optarg, "r");
+            if (!map_file) {
+                fprintf(stderr, "%s: couldn't open %s for reading: %s\n",
+                    argv0, util_optarg, strerror(errno));
+                exit(1);
+            }
+            eclmap_load(g_eclmap_opcode, g_eclmap_global, map_file, util_optarg);
+            fclose(map_file);
+            break;
+        }
+        case 'r':
+            g_ecl_rawoutput = true;
+            break;
+        case '?':
+            fprintf(stderr,"%s: Unknown option '%c'\n",argv0,util_optopt);
+            print_usage();
+            exit(1);
+        case -1:
+            if(!strcmp(argv[util_optind-1], "--")) {
+                while(argv[util_optind]) {
+                    argv[ind++] = argv[util_optind++];
+                }
+            }
+            else {
+                argv[ind++] = argv[util_optind++];
+            }
+            break;
+        }
+    }
+    argc = ind;
+    argv[argc] = NULL;
 
     switch (version) {
     case 6:
@@ -232,53 +303,27 @@ main(int argc, char* argv[])
     {
     case 'c':
     case 'd': {
-        g_eclmap_opcode = eclmap_new();
-        g_eclmap_global = eclmap_new();
-
-        int argp = 2;
-        if(!strchr(options, 'm')) {
-            if(argc > argp) {
-                FILE* map_file = NULL;
-                map_file = fopen(argv[argp], "r");
-                if (!map_file) {
-                    fprintf(stderr, "%s: couldn't open %s for reading: %s\n",
-                        argv0, argv[argp], strerror(errno));
-                    exit(1);
-                }
-                eclmap_load(g_eclmap_opcode, g_eclmap_global, map_file, argv[argp]);
-                fclose(map_file);
-            }
-            else {
-                fprintf(stderr, "%s: missing map filename\n",
-                    argv0);
-                exit(1);
-            }
-            ++argp;
-        }
-
-        if(!strchr(options, 'r')) {
+        if(g_ecl_rawoutput) {
             if (mode != 'd') {
                 fprintf(stderr, "%s: 'r' option cannot be used while compiling\n", argv0);
                 exit(1);
             }
-            g_ecl_rawoutput = true;
         }
 
-        if (argc > argp) {
-            current_input = argv[argp];
-            in = fopen(argv[argp], "rb");
+        if (0 < argc) {
+            current_input = argv[0];
+            in = fopen(argv[0], "rb");
             if (!in) {
                 fprintf(stderr, "%s: couldn't open %s for reading: %s\n",
-                    argv0, argv[argp], strerror(errno));
+                    argv0, argv[0], strerror(errno));
                 exit(1);
             }
-            ++argp;
-            if (argc > argp) {
-                current_output = argv[argp];
-                out = fopen(argv[argp], "wb");
+            if (1 < argc) {
+                current_output = argv[1];
+                out = fopen(argv[1], "wb");
                 if (!out) {
                     fprintf(stderr, "%s: couldn't open %s for writing: %s\n",
-                        argv0, argv[argp], strerror(errno));
+                        argv0, argv[1], strerror(errno));
                     fclose(in);
                     exit(1);
                 }
@@ -308,15 +353,10 @@ main(int argc, char* argv[])
         fclose(in);
         fclose(out);
         
-        eclmap_free(g_eclmap_opcode);
-        eclmap_free(g_eclmap_global);
-
         exit(0);
     }
-    case 'V':
-        util_print_version();
-        exit(0);
     default:
+        print_usage();
         exit(1);
     }
 }

--- a/thecl/thecl.c
+++ b/thecl/thecl.c
@@ -204,13 +204,10 @@ main(int argc, char* argv[])
     atexit(free_eclmaps);
 
     argv0 = argv[0];
-    char opt;
+    int opt;
     int ind=0;
     while(argv[util_optind]) {
         switch(opt = util_getopt(argc, argv, ":c:d:Vm:r")) {
-        case 'V':
-            util_print_version();
-            exit(0);
         case 'c':
         case 'd':
             if(mode != -1) {
@@ -220,19 +217,6 @@ main(int argc, char* argv[])
             }
             mode = opt;
             version = atoi(util_optarg);
-            break;
-        case ':':
-            if(util_optopt == 'm') {
-                fprintf(stderr,"%s: Missing required argument for option '%c'\n",argv0,util_optopt);
-                print_usage();
-                exit(1);
-            }
-            if(mode != -1) {
-                fprintf(stderr,"%s: More than one mode specified\n", argv0);
-                print_usage();
-                exit(1);
-            }
-            mode = util_optopt;
             break;
         case 'm': {
             FILE* map_file = NULL;
@@ -249,20 +233,8 @@ main(int argc, char* argv[])
         case 'r':
             g_ecl_rawoutput = true;
             break;
-        case '?':
-            fprintf(stderr,"%s: Unknown option '%c'\n",argv0,util_optopt);
-            print_usage();
-            exit(1);
-        case -1:
-            if(!strcmp(argv[util_optind-1], "--")) {
-                while(argv[util_optind]) {
-                    argv[ind++] = argv[util_optind++];
-                }
-            }
-            else {
-                argv[ind++] = argv[util_optind++];
-            }
-            break;
+        default:
+            util_getopt_default(&ind,argv,opt,print_usage);
         }
     }
     argc = ind;

--- a/thmsg/thmsg.1
+++ b/thmsg/thmsg.1
@@ -24,7 +24,7 @@
 .\" OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 .\" SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
 .\" DAMAGE.
-.Dd March 13, 2011
+.Dd March 16, 2018
 .Dt THMSG 1
 .Os thtk
 .Sh NAME
@@ -32,7 +32,8 @@
 .Nd Touhou dialogue tool
 .Sh SYNOPSIS
 .Nm
-.Ar command Ns Op Ar option ...
+.Op Fl Ve
+.Op Oo Fl c | d Oc Ar version
 .Op Ar input Op Ar output
 .Sh DESCRIPTION
 The
@@ -40,23 +41,23 @@ The
 utility converts dialogue files from and to a human-readable format.
 The following commands are available:
 .Bl -tag -width Ds
-.It Ar c Ns Oo Ar e Oc Ns Ar version Op Ar input Op Ar output
+.It Nm Fl c Ar version Oo Fl e Oc Op Ar input Op Ar output
 Creates a new dialogue file from the input.
-.It Ar d Ns Oo Ar e Oc Ns Ar version Op Ar input Op Ar output
+.It Nm Fl d Ar version Oo Fl e Oc Op Ar input Op Ar output
 Dumps a dialogue file.
-.It Ar V
+.It Nm Fl V
 Displays the program version.
 .El
 .Pp
 The version specifies which dialogue format to use,
 it is further modified by the presence of the
-.Ar e
+.Fl e
 option.
 Running the program without a command will list the supported formats.
 .Bl -tag -width Ds
-.It Ar e
+.It Fl e
 The
-.Ar e
+.Fl e
 option is used to process ending dialogue,
 and for the mission.msg file in TH125.
 .El
@@ -67,12 +68,12 @@ utility exits with 0 on success, 1 on error.
 .Sh EXAMPLES
 Create a new dialogue file from the input file:
 .Bd -literal -offset indent
-thmsg c10 input.txt output.msg
+thmsg -c10 input.txt output.msg
 .Ed
 .Pp
 Dump the mission descriptions to standard output:
 .Bd -literal -offset indent
-thmsg de125 mission.msg
+thmsg -ed125 mission.msg
 .Ed
 .Sh SEE ALSO
 .Lk https://github.com/thpatch/thtk "Project homepage"

--- a/thmsg/thmsg.c
+++ b/thmsg/thmsg.c
@@ -43,14 +43,14 @@ extern const thmsg_module_t th95_msg;
 static void
 print_usage(void)
 {
-    printf("Usage: %s COMMAND[OPTION...] [INPUT [OUTPUT]]\n"
-           "COMMAND can be:\n"
-           "  c  create a dialogue file\n"
-           "  d  dump a dialogue file\n"
-           "  V  display version information and exit\n"
-           "OPTION can be:\n"
-           "  e  extract or create ending dialogue\n"
-           "  #  # can be 6, 7, 8, 9, 95, 10, 11, 12, 125, 128, 13, 14, 143, 15, or 16 (required)\n"
+    printf("Usage: %s [-Ve] [[-c | -d] VERSION] [INPUT [OUTPUT]]\n"
+           "Options:\n"
+           "  -c  create a dialogue file\n"
+           "  -d  dump a dialogue file\n"
+           "  -V  display version information and exit\n"
+           "  -e  extract or create ending dialogue\n"
+           "VERSION can be:\n"
+           "  6, 7, 8, 9, 95, 10, 11, 12, 125, 128, 13, 14, 143, 15, or 16\n"
            "Report bugs to <" PACKAGE_BUGREPORT ">.\n", argv0);
 }
 

--- a/thmsg/thmsg.c
+++ b/thmsg/thmsg.c
@@ -67,13 +67,10 @@ main(int argc, char* argv[])
     current_output = "(stdout)";
 
     argv0 = argv[0];
-    char opt;
+    int opt;
     int ind=0;
     while(argv[util_optind]) {
         switch(opt = util_getopt(argc, argv, ":c:d:Ve")) {
-        case 'V':
-            util_print_version();
-            exit(0);
         case 'c':
         case 'd':
             if(mode != -1) {
@@ -84,31 +81,11 @@ main(int argc, char* argv[])
             mode = opt;
             version = atoi(util_optarg);
             break;
-        case ':':
-            if(mode != -1) {
-                fprintf(stderr,"%s: More than one mode specified\n", argv0);
-                print_usage();
-                exit(1);
-            }
-            mode = util_optopt;
-            break;
         case 'e':
             thmsg_opt_end = 1;
             break;
-        case '?':
-            fprintf(stderr,"%s: Unknown option '%c'\n",argv0,util_optopt);
-            print_usage();
-            exit(1);
-        case -1:
-            if(!strcmp(argv[util_optind-1], "--")) {
-                while(argv[util_optind]) {
-                    argv[ind++] = argv[util_optind++];
-                }
-            }
-            else {
-                argv[ind++] = argv[util_optind++];
-            }
-            break;
+        default:
+            util_getopt_default(&ind,argv,opt,print_usage);
         }
     }
     argc = ind;

--- a/thmsg/thmsg.c
+++ b/thmsg/thmsg.c
@@ -66,7 +66,7 @@ main(int argc, char* argv[])
     current_input = "(stdin)";
     current_output = "(stdout)";
 
-    argv0 = argv[0];
+    argv0 = util_shortname(argv[0]);
     int opt;
     int ind=0;
     while(argv[util_optind]) {

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -1,4 +1,4 @@
 add_library(util STATIC
-  file.c list.c program.c util.c value.c
-  file.h list.h program.h util.h value.h
+  file.c list.c program.c util.c value.c mygetopt.c
+  file.h list.h program.h util.h value.h mygetopt.h
 )

--- a/util/mygetopt.c
+++ b/util/mygetopt.c
@@ -1,0 +1,81 @@
+/* This is free and unencumbered software released into the public domain.
+ *
+ * Anyone is free to copy, modify, publish, use, compile, sell, or
+ * distribute this software, either in source code form or as a compiled
+ * binary, for any purpose, commercial or non-commercial, and by any
+ * means.
+ *
+ * In jurisdictions that recognize copyright laws, the author or authors
+ * of this software dedicate any and all copyright interest in the
+ * software to the public domain. We make this dedication for the benefit
+ * of the public at large and to the detriment of our heirs and
+ * successors. We intend this dedication to be an overt act of
+ * relinquishment in perpetuity of all present and future rights to this
+ * software under copyright law.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * For more information, please refer to <http://unlicense.org/>
+ **/
+#include <stdio.h> /* for fprintf, stderr, NULL */
+#include <ctype.h> /* for isalnum */
+#include <string.h> /* for strchr */
+#define MYGETOPT_KEEPDEFINES
+#include "mygetopt.h"
+
+char *optarg = NULL;
+int opterr = 1, optind = 1, optopt = 0;
+int getopt(int argc, char *const argv[], const char *optstring) {
+	static char* arg = NULL;
+	char*p;
+	int rv;
+	if(optind >= argc || !argv || !optstring) return -1;
+	if(arg == NULL) {
+		char *temp = argv[optind];
+		if(temp == NULL) return -1;
+		if(temp[0] != '-') return -1;
+		if(temp[1] == '\0') return -1;
+		if(temp[1] == '-' && temp[2] == '\0') { optind++; return -1; }
+		arg = temp+1;
+	}
+	
+	optopt = *arg++;
+	if(isalnum(optopt) && (p=strchr(optstring,optopt))) {
+		rv = optopt;
+		if(p[1] == ':') {
+			if(*arg) {
+				/* argument of form -ffilename */
+				optarg = arg;
+				arg = NULL;
+				optind++;
+			}
+			else {
+				/* argument of form -f filename */
+				optarg = argv[++optind]; /* optind will be increased second time later */
+				if(!optarg) {
+					if(opterr && optstring[0] != ':')
+						fprintf(stderr, "%s: Option -%c requires an operand\n", argv[0], optopt);
+					rv = optstring[0] == ':' ? ':' : '?';
+				}
+			}
+		}
+	}
+	else {
+		if(opterr && optstring[0] != ':')
+			fprintf(stderr, "%s: Unrecognized option: '-%c'\n", argv[0], optopt);
+		rv = '?';
+	}
+
+	if(arg && *arg == '\0') {
+		arg = NULL;
+		optind++;
+	}
+
+	return rv;
+}

--- a/util/mygetopt.h
+++ b/util/mygetopt.h
@@ -1,0 +1,46 @@
+/* This is free and unencumbered software released into the public domain.
+ *
+ * Anyone is free to copy, modify, publish, use, compile, sell, or
+ * distribute this software, either in source code form or as a compiled
+ * binary, for any purpose, commercial or non-commercial, and by any
+ * means.
+ *
+ * In jurisdictions that recognize copyright laws, the author or authors
+ * of this software dedicate any and all copyright interest in the
+ * software to the public domain. We make this dedication for the benefit
+ * of the public at large and to the detriment of our heirs and
+ * successors. We intend this dedication to be an overt act of
+ * relinquishment in perpetuity of all present and future rights to this
+ * software under copyright law.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * For more information, please refer to <http://unlicense.org/>
+ **/
+#ifndef MYGETOPT_H_
+#define MYGETOPT_H_
+#define MYGETOPT_PREFIX(x) util_##x
+#ifdef MYGETOPT_PREFIX
+#  define optarg MYGETOPT_PREFIX(optarg)
+#  define opterr MYGETOPT_PREFIX(opterr)
+#  define optind MYGETOPT_PREFIX(optind)
+#  define optopt MYGETOPT_PREFIX(optopt)
+#  define getopt MYGETOPT_PREFIX(getopt)
+#endif
+extern char *optarg;
+extern int opterr, optind, optopt;
+int getopt(int argc, char *const argv[], const char *optstring);
+#if defined(MYGETOPT_PREFIX) && !defined(MYGETOPT_KEEPDEFINES)
+#  undef optarg
+#  undef opterr
+#  undef optind
+#  undef optopt
+#  undef getopt
+#endif
+#endif

--- a/util/program.c
+++ b/util/program.c
@@ -43,7 +43,7 @@ const char* current_output = NULL;
 /* Returns a pointer to after the last directory separator in path. */
 /* TODO: Use util_basename if it can be made to return a pointer to inside of
  * path. */
-static const char*
+const char*
 util_shortname(
     const char* path)
 {

--- a/util/program.c
+++ b/util/program.c
@@ -34,6 +34,7 @@
 #include <string.h>
 #include "program.h"
 #include "util.h"
+#include "mygetopt.h"
 
 const char* argv0 = NULL;
 const char* current_input = NULL;
@@ -59,55 +60,34 @@ util_shortname(
     return ret ? ret + 1 : path;
 }
 
-int
-parse_args(
-    int argc,
-    char* argv[],
-    void (*usage)(void),
-    const char* commands,
-    char* options,
-    unsigned int* version)
+void
+util_getopt_default(
+    int *ind,
+    char **argv,
+    int opt,
+    void (*usage)(void))
 {
-    int command;
-    char* argp;
-
-    /* TODO: Some kind of check here first. */
-    argv0 = util_shortname(argv[0]);
-
-    if (argc < 2) {
+    switch(opt) {
+    case 'V':
+        util_print_version();
+        exit(0);
+    case ':':
+        fprintf(stderr,"%s: Missing required argument for option '%c'\n",argv0,util_optopt);
         usage();
-        return 0;
-    }
-
-    command = argv[1][0];
-
-    if (!command) {
-        fprintf(stderr, "%s: command missing\n", argv0);
-        return 0;
-    }
-
-    if (!strchr(commands, command)) {
-        fprintf(stderr, "%s: unknown command '%c'\n", argv0, command);
+        exit(1);
+    case '?':
+        fprintf(stderr,"%s: Unknown option '%c'\n",argv0,util_optopt);
         usage();
-        return 0;
-    }
-
-    for (argp = argv[1] + 1; *argp;) {
-        char* optionp = strchr(options, *argp);
-        if (optionp) {
-            *optionp = ' ';
-            argp++;
-        } else {
-            long int parsed_version = strtol(argp, &argp, 10);
-            if (!version || parsed_version == 0 || parsed_version == LONG_MIN
-                || parsed_version == LONG_MAX) {
-                fprintf(stderr, "%s: unrecognized option '%c'\n", argv0, *argp);
-                usage();
-                return 0;
-            } else
-                *version = parsed_version;
+        exit(1);
+    case -1:
+        if(!strcmp(argv[util_optind-1], "--")) {
+            while(argv[util_optind]) {
+                argv[(*ind)++] = argv[util_optind++];
+            }
         }
+        else {
+            argv[(*ind)++] = argv[util_optind++];
+        }
+        break;
     }
-
-    return command;
 }

--- a/util/program.h
+++ b/util/program.h
@@ -31,21 +31,11 @@
 
 #include <config.h>
 
-/* Parses the arguments, the expected format is
- * "argv0 COMMAND[OPTIONS...] [...]".
- *
- * OPTIONS can contain a number which is assigned to version.  Enabled options
- * are replaced by spaces in the passed string so that they can be checked by
- * "!strchr(options, option)".
- *
- * Also sets the global argv0. */
-int parse_args(
-    int argc,
-    char* argv[],
-    void (*usage)(void),
-    const char* commands,
-    char* options,
-    unsigned int* version);
+void util_getopt_default(
+    int *ind,
+    char **argv,
+    int opt,
+    void (*usage)(void));
 
 extern const char* argv0;
 extern const char* current_input;

--- a/util/program.h
+++ b/util/program.h
@@ -31,6 +31,9 @@
 
 #include <config.h>
 
+const char* util_shortname(
+        const char* path);
+
 void util_getopt_default(
     int *ind,
     char **argv,


### PR DESCRIPTION
Pros:
* More flexible and extensible
* Standard syntax
* Adding an option with argument is no longer PITA
* Multiple ecl maps can be loaded now, just from the fact that you can specify multiple -m switches

Cons:
* Different, incompatible syntax from before (will break any unofficial GUIs)
* ~~Need to rewrite documentation~~ done
* ~~Need to rewrite print_usages~~ done
* Not specifying version for thdat won't work anymore. (setting the default to latest game was dumb anyway :p)
* C standard isn't clear on whether argv[n] is modifiable.
* I haven't tested it that much. Someone plz test.

~~if someone wants to work on documentation, feel free to assign yourself. Otherwise I'll do it myself in 3️⃣ days™️~~  done

(by the way, -d option in thdat is supposed to be used for testing detect. leave it undocumented for now.)