### PR TITLE
Some new features and bug fixes in thecl

### DIFF
--- a/thecl/ecsparse.y
+++ b/thecl/ecsparse.y
@@ -760,20 +760,20 @@ Case:
     /* TODO: Check the given parameters against the parameters expected for the
      *       instruction. */
 Instruction:
-      IDENTIFIER "(" Instruction_Parameters ")" "sub" {
+      "@" IDENTIFIER "(" Instruction_Parameters ")" {
           /* Force creating a sub call, even if it wasn't defined in the file earlier - useful for calling subs from default.ecl */
-          instr_create_call(state, 11, $1, $3);
-          if ($3 != NULL) {
-              list_free_nodes($3);
-              free($3);
+          instr_create_call(state, 11, $2, $4);
+          if ($4 != NULL) {
+              list_free_nodes($4);
+              free($4);
           }
       }
-      | IDENTIFIER "(" Instruction_Parameters ")" "sub" "async" {
+      | "@" IDENTIFIER "(" Instruction_Parameters ")" "async" {
           /* Same as above, except use ins_15 (callAsync) instead of ins_11 (call) */
-          instr_create_call(state, 15, $1, $3);
-          if ($3 != NULL) {
-              list_free_nodes($3);
-              free($3);
+          instr_create_call(state, 15, $2, $4);
+          if ($4 != NULL) {
+              list_free_nodes($4);
+              free($4);
           }
       } 
       | IDENTIFIER "(" Instruction_Parameters ")" "async" {

--- a/thecl/ecsparse.y
+++ b/thecl/ecsparse.y
@@ -762,7 +762,7 @@ Case:
 Instruction:
       "@" IDENTIFIER "(" Instruction_Parameters ")" {
           /* Force creating a sub call, even if it wasn't defined in the file earlier - useful for calling subs from default.ecl */
-          instr_create_call(state, 11, $2, $4);
+          instr_create_call(state, TH10_INS_CALL, $2, $4);
           if ($4 != NULL) {
               list_free_nodes($4);
               free($4);
@@ -770,7 +770,7 @@ Instruction:
       }
       | "@" IDENTIFIER "(" Instruction_Parameters ")" "async" {
           /* Same as above, except use ins_15 (callAsync) instead of ins_11 (call) */
-          instr_create_call(state, 15, $2, $4);
+          instr_create_call(state, TH10_INS_CALL_ASYNC, $2, $4);
           if ($4 != NULL) {
               list_free_nodes($4);
               free($4);
@@ -786,7 +786,7 @@ Instruction:
               }
           }
           if (sub_found) {
-              instr_create_call(state, 15, $1, $3);
+              instr_create_call(state, TH10_INS_CALL_ASYNC, $1, $3);
               if ($3 != NULL) list_free_nodes($3);
           } else {
               char errbuf[256];
@@ -816,7 +816,7 @@ Instruction:
                 }
             }
             if (sub_found) {
-                instr_create_call(state, 11, $1, $3);
+                instr_create_call(state, TH10_INS_CALL, $1, $3);
                 if ($3 != NULL) list_free_nodes($3);;
             } else {
                 char errbuf[256];

--- a/thecl/ecsparse.y
+++ b/thecl/ecsparse.y
@@ -1474,11 +1474,11 @@ expression_output(
         instr_add(state->current_sub, instr_new(state, expr->id, ""));
     } else if (expr->type == EXPRESSION_RANK_SWITCH) {
         int diff = 0;
-        char* diffs[5] = {"E", "N", "H", "L"};
+        char* diffs[4] = {"E", "N", "H", "L"};
         int ins_number = expr->result_type == 'S' ? 42 : 44; //  42 and 44 are ins numbers for pushing int/float to ECL stack
-        int val;
-        list_for_each(&expr->children, val) {
-            thecl_instr_t* instr = instr_new(state, ins_number, "p", val);
+        thecl_param_t* param;
+        list_for_each(&expr->children, param) {
+            thecl_instr_t* instr = instr_new(state, ins_number, "p", param);
             instr->rank = parse_rank(state, diffs[diff++]);
             instr_add(state->current_sub, instr);
         }

--- a/thecl/ecsparse.y
+++ b/thecl/ecsparse.y
@@ -1410,16 +1410,22 @@ expression_rank_switch_new(
     const parser_state_t* state, const int* type, 
     const thecl_param_t* valE, const thecl_param_t* valN, const thecl_param_t* valH, const thecl_param_t* valL
 ) {
-    expression_t* expr = malloc(sizeof(expression_t));
-    expr->type = EXPRESSION_RANK_SWITCH;
-    expr->result_type = type;
-    list_t* list = list_new();
-    list_append_new(list, valE);
-    list_append_new(list, valN);
-    list_append_new(list, valH);
-    list_append_new(list, valL);
-    expr->children = *list;
-    return expr;
+    if (not_pre_th10(state->ecl->version)) {
+        expression_t* expr = malloc(sizeof(expression_t));
+        expr->type = EXPRESSION_RANK_SWITCH;
+        expr->result_type = type;
+        list_t* list = list_new();
+        list_append_new(list, valE);
+        list_append_new(list, valN);
+        list_append_new(list, valH);
+        list_append_new(list, valL);
+        expr->children = *list;
+        return expr;
+    }
+    char buf[256] = "difficulty switch expression is not available in pre-th10 ECL";
+    yyerror((parser_state_t *)state, buf);
+
+    exit(2);
 }
 
 static expression_t *
@@ -1559,11 +1565,13 @@ static void
 sub_finish(
     parser_state_t* state)
 {
-    instr_prepend(state->current_sub, instr_new(state, 40, "S", state->current_sub->stack));
+    if (not_pre_th10(state->ecl->version)) {
+        instr_prepend(state->current_sub, instr_new(state, 40, "S", state->current_sub->stack));
 
-    thecl_instr_t* last_ins = list_tail(&state->current_sub->instrs);
-    if (last_ins == NULL || last_ins->id != 10 && last_ins->id != 1) {
-        instr_add(state->current_sub, instr_new(state, 10, ""));
+        thecl_instr_t* last_ins = list_tail(&state->current_sub->instrs);
+        if (last_ins == NULL || last_ins->id != 10 && last_ins->id != 1) {
+            instr_add(state->current_sub, instr_new(state, 10, ""));
+        }
     }
 
     state->current_sub = NULL;

--- a/thecl/ecsparse.y
+++ b/thecl/ecsparse.y
@@ -293,7 +293,6 @@ Statement:
             state->current_sub->stack = state->current_sub->arity * 4;
       }
       "{" Subroutine_Body "}" {
-        instr_prepend(state->current_sub, instr_new(state, 40, "S", state->current_sub->stack));
         sub_finish(state);
       }
     | "anim" "{" Text_Semicolon_List "}" {
@@ -1560,6 +1559,13 @@ static void
 sub_finish(
     parser_state_t* state)
 {
+    instr_prepend(state->current_sub, instr_new(state, 40, "S", state->current_sub->stack));
+
+    thecl_instr_t* last_ins = list_tail(&state->current_sub->instrs);
+    if (last_ins == NULL || last_ins->id != 10 && last_ins->id != 1) {
+        instr_add(state->current_sub, instr_new(state, 10, ""));
+    }
+
     state->current_sub = NULL;
 }
 

--- a/thecl/ecsparse.y
+++ b/thecl/ecsparse.y
@@ -670,14 +670,18 @@ Instruction:
       IDENTIFIER "(" Instruction_Parameters ")" "sub" {
           /* Force creating a sub call, even if it wasn't defined in the file earlier - useful for calling subs from default.ecl */
           instr_create_call(state, 11, $1, $3);
-          list_free_nodes($3);
-          free($3);
+          if ($3 != NULL) {
+              list_free_nodes($3);
+              free($3);
+          }
       }
       | IDENTIFIER "(" Instruction_Parameters ")" "sub" "async" {
           /* Same as above, except use ins_15 (callAsync) instead of ins_11 (call) */
           instr_create_call(state, 15, $1, $3);
-          list_free_nodes($3);
-          free($3);
+          if ($3 != NULL) {
+              list_free_nodes($3);
+              free($3);
+          }
       } 
       | IDENTIFIER "(" Instruction_Parameters ")" "async" {
           /* Search for sub */
@@ -690,7 +694,7 @@ Instruction:
           }
           if (sub_found) {
               instr_create_call(state, 15, $1, $3);
-              list_free_nodes($3);
+              if ($3 != NULL) list_free_nodes($3);
           } else {
               char errbuf[256];
               snprintf(errbuf, 256, "unknown sub: %s", $1);
@@ -720,7 +724,7 @@ Instruction:
             }
             if (sub_found) {
                 instr_create_call(state, 11, $1, $3);
-                list_free_nodes($3);
+                if ($3 != NULL) list_free_nodes($3);;
             } else {
                 char errbuf[256];
                 snprintf(errbuf, 256, "unknown mnemonic: %s", $1);

--- a/thecl/ecsparse.y
+++ b/thecl/ecsparse.y
@@ -395,7 +395,7 @@ Text_Semicolon_List:
       }
     ;
 
-VarDeclaration:
+VarDeclareMany:
     "var" Optional_Identifier_Whitespace_List {
         size_t var_list_length = 0;
         string_t* str;
@@ -410,6 +410,50 @@ VarDeclaration:
 
         state->current_sub->stack += var_list_length * 4;
     }
+    ;
+
+VarDeclareAssign:
+      VarIntegerAssign
+    | VarFloatAssign
+    ;
+
+VarIntegerAssign:
+    "var" "$" IDENTIFIER "=" Expression {
+        var_create(state->current_sub, $3);
+        state->current_sub->stack += 4;
+
+        expression_output(state, $5);
+        expression_free($5);
+
+        thecl_param_t* param = param_new('S');
+        param->value.type = 'S';
+        param->value.val.S = state->current_sub->stack - 4;
+        param->stack = 1;
+
+        instr_add(state->current_sub, instr_new(state, 43, "p", param));
+    }
+    ;
+
+VarFloatAssign:
+    "var" "%" IDENTIFIER "=" Expression {
+        var_create(state->current_sub, $3);
+        state->current_sub->stack += 4;
+
+        expression_output(state, $5);
+        expression_free($5);
+
+        thecl_param_t* param = param_new('f');
+        param->value.type = 'f';
+        param->value.val.f = state->current_sub->stack - 4;
+        param->stack = 1;
+
+        instr_add(state->current_sub, instr_new(state, 45, "p", param));
+    }
+    ;
+
+VarDeclaration:
+      VarDeclareMany
+    | VarDeclareAssign
     ;
 
 Instructions:

--- a/thecl/ecsparse.y
+++ b/thecl/ecsparse.y
@@ -1517,7 +1517,8 @@ expression_output(
 
         instr_add(state->current_sub, instr_new(state, expr->id, ""));
     } else if (expr->type == EXPRESSION_RANK_SWITCH) {
-        const int diff_amt = 5;
+
+        const int diff_amt = state->has_overdrive_difficulty ? 5 : 4;
         const char* diffs[5] = {"E", "N", "H", "L", "O"};
 
         int diff = 0;
@@ -1545,7 +1546,7 @@ expression_output(
             char* next_diff = diffs[diff++];
             strcat(diff_str, next_diff);
         }
-        
+
         instr->rank = parse_rank(state, diff_str);
         instr_add(state->current_sub, instr);
     }

--- a/thecl/ecsparse.y
+++ b/thecl/ecsparse.y
@@ -1566,7 +1566,10 @@ sub_finish(
     parser_state_t* state)
 {
     if (not_pre_th10(state->ecl->version)) {
-        instr_prepend(state->current_sub, instr_new(state, 40, "S", state->current_sub->stack));
+        
+        thecl_instr_t* var_ins = instr_new(state, 40, "S", state->current_sub->stack);
+        var_ins->time = 0;
+        instr_prepend(state->current_sub, var_ins);
 
         thecl_instr_t* last_ins = list_tail(&state->current_sub->instrs);
         if (last_ins == NULL || last_ins->id != 10 && last_ins->id != 1) {

--- a/thecl/ecsparse.y
+++ b/thecl/ecsparse.y
@@ -479,23 +479,22 @@ VarDeclaration:
 
 Instructions:
       Instruction ";"
-    | IfBlock
-    | WhileBlock
-    | TimesBlock
-    | SwitchBlock
-    | BreakStatement
+    | Block
     | INTEGER ":" { set_time(state, $1); }
     | IDENTIFIER ":" { label_create(state, $1); free($1); }
     | Instructions INTEGER ":" { set_time(state, $2); }
     | Instructions IDENTIFIER ":" { label_create(state, $2); free($2); }
     | Instructions Instruction ";"
-    | Instructions IfBlock
-    | Instructions SwitchBlock
-    | Instructions WhileBlock
-    | Instructions TimesBlock
-    | RANK { state->instr_rank = parse_rank(state, $1); } Instruction ";"
-    | Instructions RANK { state->instr_rank = parse_rank(state, $2); } Instruction ";"
-    | Instructions BreakStatement
+    | Instructions Block
+    | RANK { state->instr_rank = parse_rank(state, $1); } 
+    | Instructions RANK { state->instr_rank = parse_rank(state, $2); } 
+    ;
+
+Block:
+      IfBlock
+    | WhileBlock
+    | TimesBlock
+    | SwitchBlock
     ;
 
 BreakStatement:
@@ -871,6 +870,7 @@ Instruction:
         expression_free($1);
       }
     | VarDeclaration
+    | BreakStatement
     ;
 
 Instruction_Parameters:

--- a/thecl/ecsparse.y
+++ b/thecl/ecsparse.y
@@ -402,6 +402,12 @@ Text_Semicolon_List:
 
 VarDeclareMany:
     "var" Optional_Identifier_Whitespace_List {
+        if (!not_pre_th10(state->version)) {
+            char buf[256];
+            snprintf(buf, 256, "stack variable declaration is not allowed in version: %i", state->version);
+            yyerror(state, buf);
+            exit(2);
+        }
         size_t var_list_length = 0;
         string_t* str;
 
@@ -428,6 +434,12 @@ VarDeclareAssign:
 
 VarIntegerAssign:
     "var" "$" IDENTIFIER "=" Expression {
+        if (!not_pre_th10(state->version)) {
+            char buf[256];
+            snprintf(buf, 256, "stack variable declaration is not allowed in version: %i", state->version);
+            yyerror(state, buf);
+            exit(2);
+        }
         if (g_ecl_simplecreate) {
             yyerror(state, "var creation with assignment is not allowed in simple creation mode");
             exit(2);
@@ -451,6 +463,12 @@ VarIntegerAssign:
 
 VarFloatAssign:
     "var" "%" IDENTIFIER "=" Expression {
+        if (!not_pre_th10(state->version)) {
+            char buf[256];
+            snprintf(buf, 256, "stack variable declaration is not allowed in version: %i", state->version);
+            yyerror(state, buf);
+            exit(2);
+        }
         if (g_ecl_simplecreate) {
             yyerror(state, "var creation with assignment is not allowed in simple creation mode");
             exit(2);

--- a/thecl/ecsparse.y
+++ b/thecl/ecsparse.y
@@ -968,13 +968,8 @@ Rank_Switch_Next_Value:
 
 Rank_Switch_List:
       Rank_Switch_Value Rank_Switch_Next_Value_List {
-        $$ = list_new();
-        list_append_new($$, $1);
-
-        thecl_param_t* param;
-        list_for_each($2, param) {
-            list_append_new($$, param);
-        }
+        $$ = $2;
+        list_prepend_new($$, $1);
       }
     ;
 

--- a/thecl/ecsparse.y
+++ b/thecl/ecsparse.y
@@ -621,7 +621,19 @@ Case:
     /* TODO: Check the given parameters against the parameters expected for the
      *       instruction. */
 Instruction:
-      IDENTIFIER "(" Instruction_Parameters ")" "async" {
+      IDENTIFIER "(" Instruction_Parameters ")" "sub" {
+          /* Force creating a sub call, even if it wasn't defined in the file earlier - useful for calling subs from default.ecl */
+          instr_create_call(state, 11, $1, $3);
+          list_free_nodes($3);
+          free($3);
+      }
+      | IDENTIFIER "(" Instruction_Parameters ")" "sub" "async" {
+          /* Same as above, except use ins_15 (callAsync) instead of ins_11 (call) */
+          instr_create_call(state, 15, $1, $3);
+          list_free_nodes($3);
+          free($3);
+      } 
+      | IDENTIFIER "(" Instruction_Parameters ")" "async" {
           /* Search for sub */
           bool sub_found = false;
           thecl_sub_t* iter_sub;

--- a/thecl/ecsparse.y
+++ b/thecl/ecsparse.y
@@ -1127,6 +1127,14 @@ instr_create_call(
             list_append_new(param_list, param);
         }
 
+    /* Output expressions from parameters. */
+    expression_t* expr;
+    list_for_each(&state->expressions, expr) {
+        expression_output(state, expr);
+        expression_free(expr);
+    }
+    list_free_nodes(&state->expressions);
+
     instr_add(state->current_sub, instr_new_list(state, type, param_list));
 }
 

--- a/thecl/ecsparse.y
+++ b/thecl/ecsparse.y
@@ -435,7 +435,8 @@ VarIntegerAssign:
         param->value.val.S = state->current_sub->stack - 4;
         param->stack = 1;
 
-        instr_add(state->current_sub, instr_new(state, 43, "p", param));
+        const expr_t* expr = expr_get_by_symbol(state->version, ASSIGNI);
+        instr_add(state->current_sub, instr_new(state, expr->id, "p", param));
     }
     ;
 
@@ -452,7 +453,8 @@ VarFloatAssign:
         param->value.val.f = state->current_sub->stack - 4;
         param->stack = 1;
 
-        instr_add(state->current_sub, instr_new(state, 45, "p", param));
+        const expr_t* expr = expr_get_by_symbol(state->version, ASSIGNF);
+        instr_add(state->current_sub, instr_new(state, expr->id, "p", param));
     }
     ;
 
@@ -623,7 +625,9 @@ TimesBlock:
           thecl_param_t* param = param_new('S');
           param->stack = 1;
           param->value.val.S = state->current_sub->stack - 4;
-          instr_add(state->current_sub, instr_new(state, 43, "p", param));
+
+          const expr_t* expr = expr_get_by_symbol(state->version, ASSIGNI);
+          instr_add(state->current_sub, instr_new(state, expr->id, "p", param));
 
           char labelstr_st[256];
           char labelstr_end[256];
@@ -646,7 +650,9 @@ TimesBlock:
           thecl_param_t* param = param_new('S');
           param->stack = 1;
           param->value.val.S = var_find(state, state->current_sub, (char*)head->data);
-          instr_add(state->current_sub, instr_new(state, 78, "p", param));
+
+          const expr_t* expr = expr_get_by_symbol(state->version, DEC);
+          instr_add(state->current_sub, instr_new(state, expr->id, "p", param));
          
           expression_create_goto(state, IF, labelstr_st);
           
@@ -681,7 +687,10 @@ SwitchBlock:
               expression_t *copy = expression_copy($2);
               expression_output(state, copy);
               expression_free(copy);
-              instr_add(state->current_sub, instr_new(state, 59, ""));
+
+              const expr_t* expr = expr_get_by_symbol(state->version, EQUALI);
+              instr_add(state->current_sub, instr_new(state, expr->id, ""));
+
               expression_free(switch_case->expr);
               expression_create_goto(state, IF, switch_case->labelstr);
               list_node_t *buf = node;
@@ -1684,13 +1693,13 @@ sub_finish(
 {
     if (not_pre_th10(state->ecl->version)) {
         
-        thecl_instr_t* var_ins = instr_new(state, 40, "S", state->current_sub->stack);
+        thecl_instr_t* var_ins = instr_new(state, TH10_INS_STACK_ALLOC, "S", state->current_sub->stack);
         var_ins->time = 0;
         instr_prepend(state->current_sub, var_ins);
 
         thecl_instr_t* last_ins = list_tail(&state->current_sub->instrs);
-        if (last_ins == NULL || last_ins->id != 10 && last_ins->id != 1) {
-            instr_add(state->current_sub, instr_new(state, 10, ""));
+        if (last_ins == NULL || last_ins->id != TH10_INS_RET_NORMAL && last_ins->id != TH10_INS_RET_BIG) {
+            instr_add(state->current_sub, instr_new(state, TH10_INS_RET_NORMAL, ""));
         }
     }
 

--- a/thecl/ecsparse.y
+++ b/thecl/ecsparse.y
@@ -794,6 +794,18 @@ Instruction_Parameter:
             $$->value.val.f = -1.0f;
         }
       }
+      | Expression {
+          list_prepend_new(&state->expressions, $1);
+
+          $$ = param_new($1->result_type);
+          $$->stack = 1;
+          $$->is_expression_param = $1->result_type;
+          if ($1->result_type == 'S') {
+              $$->value.val.S = -1;
+          } else {
+              $$->value.val.f = -1.0f;
+          }
+      }
     ;
 
 Expression:

--- a/thecl/ecsparse.y
+++ b/thecl/ecsparse.y
@@ -498,7 +498,7 @@ Block:
     ;
 
 BreakStatement:
-      "break" ";" {
+      "break" {
           list_node_t *head = state->block_stack.head;
           for(; head; head = head->next) {
               if (

--- a/thecl/ecsscan.l
+++ b/thecl/ecsscan.l
@@ -84,6 +84,7 @@
 "else"     return ELSE;
 "do"       return DO;
 "while"    return WHILE;
+"times"    return TIMES;
 "switch"   return SWITCH;
 "case"     return CASE;
 "break"    return BREAK;

--- a/thecl/ecsscan.l
+++ b/thecl/ecsscan.l
@@ -126,6 +126,10 @@ _fS return CAST_FI;
     yylval.floating = strtof(yytext, NULL);
     return FLOATING;
 }
+-?[0-9]+(\.[0-9]*)?deg {
+    yylval.floating = strtof(yytext, NULL) / 180.0f * 3.14159265359f;
+    return FLOATING;
+}
 ins_[0-9]+ {
     yylval.integer = strtol(yytext + 4, NULL, 10);
     return INSTRUCTION;

--- a/thecl/ecsscan.l
+++ b/thecl/ecsscan.l
@@ -142,6 +142,12 @@ ins_[0-9]+ {
     yylval.integer = strtol(yytext, NULL, 16);
     return INTEGER;
 }
+-?0b[0-1]+ {
+    bool isNegative = yytext[0] == '-';
+    yylval.integer = strtol(yytext + (isNegative ? 3 : 2), NULL, 2);
+    if (isNegative) yylval.integer = -yylval.integer;
+    return INTEGER;
+}
 ![-*ENHLWXYZO4567]+ {
     yylval.string = strdup(yytext + 1);
     return RANK;

--- a/thecl/ecsscan.l
+++ b/thecl/ecsscan.l
@@ -126,8 +126,8 @@ _fS return CAST_FI;
     yylval.floating = strtof(yytext, NULL);
     return FLOATING;
 }
--?[0-9]+(\.[0-9]*)?deg {
-    yylval.floating = strtof(yytext, NULL) / 180.0f * 3.14159265359f;
+rad\(-?[0-9]+(\.[0-9]*)?f\) {
+    yylval.floating = strtof(yytext+4, NULL) / 180.0f * 3.14159265359f;
     return FLOATING;
 }
 ins_[0-9]+ {

--- a/thecl/expr.c
+++ b/thecl/expr.c
@@ -115,19 +115,7 @@ th10_expressions[] = {
 static const expr_t*
 expr_get_table(unsigned int version)
 {
-    if (   version == 10
-        || version == 103
-        || version == 11
-        || version == 12
-        || version == 125
-        || version == 128
-        || version == 13
-        || version == 14
-        || version == 143
-        || version == 15
-        || version == 16
-        || version == 165
-        || version == 17)
+    if (not_pre_th10(version))
         return th10_expressions;
     return th10_no_expressions;
 }

--- a/thecl/thecl.c
+++ b/thecl/thecl.c
@@ -173,6 +173,25 @@ free_eclmaps(void)
     eclmap_free(g_eclmap_global);
 }
 
+int
+not_pre_th10(
+    unsigned int version)
+{
+    return version == 10
+        || version == 103
+        || version == 11
+        || version == 12
+        || version == 125
+        || version == 128
+        || version == 13
+        || version == 14
+        || version == 143
+        || version == 15
+        || version == 16
+        || version == 165
+        || version == 17;
+}
+
 static void
 print_usage(void)
 {

--- a/thecl/thecl.c
+++ b/thecl/thecl.c
@@ -42,6 +42,7 @@ extern const thecl_module_t th10_ecl;
 eclmap_t* g_eclmap_opcode = NULL;
 eclmap_t* g_eclmap_global = NULL;
 bool g_ecl_rawoutput = false;
+bool g_ecl_simplecreate = false;
 bool g_was_error = false;
 
 thecl_t*
@@ -202,6 +203,7 @@ print_usage(void)
            "  -V  display version information and exit\n"
            "  -m  use map file for translating mnemonics\n"
            "  -r  output raw ECL opcodes, applying minimal transformations\n"
+           "  -s  use simple creation, which doesn't add any instructions automatically\n"
            "VERSION can be:\n"
            "  6, 7, 8, 9, 95, 10, 103 (for Uwabami Breakers), 11, 12, 125, 128, 13, 14, 143, 15, 16, 165 or 17\n"
            "Report bugs to <" PACKAGE_BUGREPORT ">.\n", argv0);
@@ -227,7 +229,7 @@ main(int argc, char* argv[])
     int opt;
     int ind=0;
     while(argv[util_optind]) {
-        switch(opt = util_getopt(argc, argv, ":c:d:Vm:r")) {
+        switch(opt = util_getopt(argc, argv, ":c:d:Vm:r:s")) {
         case 'c':
         case 'd':
             if(mode != -1) {
@@ -252,6 +254,9 @@ main(int argc, char* argv[])
         }
         case 'r':
             g_ecl_rawoutput = true;
+            break;
+        case 's':
+            g_ecl_simplecreate = true;
             break;
         default:
             util_getopt_default(&ind,argv,opt,print_usage);
@@ -300,6 +305,12 @@ main(int argc, char* argv[])
         if(g_ecl_rawoutput) {
             if (mode != 'd') {
                 fprintf(stderr, "%s: 'r' option cannot be used while compiling\n", argv0);
+                exit(1);
+            }
+        }
+        if (g_ecl_simplecreate) {
+            if (mode != 'c') {
+                fprintf(stderr, "%s: 's' option cannot be used while dumping\n", argv0);
                 exit(1);
             }
         }

--- a/thecl/thecl.h
+++ b/thecl/thecl.h
@@ -69,6 +69,9 @@ thecl_param_t* param_new(
 void param_free(
     thecl_param_t* param);
 
+int not_pre_th10(
+    unsigned int version);
+
 typedef struct thecl_instr_t {
     thecl_instr_type type;
     char* string;

--- a/thecl/thecl.h
+++ b/thecl/thecl.h
@@ -60,6 +60,8 @@ typedef enum {
 // Numbers of important ECL instructions
 #define TH10_INS_RET_BIG        1
 #define TH10_INS_RET_NORMAL     10
+#define TH10_INS_CALL           11
+#define TH10_INS_CALL_ASYNC     15
 #define TH10_INS_STACK_ALLOC    40
 
 typedef struct thecl_param_t {

--- a/thecl/thecl.h
+++ b/thecl/thecl.h
@@ -196,6 +196,7 @@ extern int yyparse(parser_state_t*);
 extern eclmap_t* g_eclmap_opcode;
 extern eclmap_t* g_eclmap_global;
 extern bool g_ecl_rawoutput;
+extern bool g_ecl_simplecreate;
 extern bool g_was_error;
 
 #endif

--- a/thecl/thecl.h
+++ b/thecl/thecl.h
@@ -57,6 +57,11 @@ typedef enum {
 #define RANK_ID_6      (1 << 6)
 #define RANK_ID_7      (1 << 7)
 
+// Numbers of important ECL instructions
+#define TH10_INS_RET_BIG        1
+#define TH10_INS_RET_NORMAL     10
+#define TH10_INS_STACK_ALLOC    40
+
 typedef struct thecl_param_t {
     int type;
     value_t value;

--- a/thecl/thecl06.c
+++ b/thecl/thecl06.c
@@ -865,10 +865,10 @@ th06_dump(
                         (instr->rank) & RANK_NORMAL  ? "N" : "",
                         (instr->rank) & RANK_HARD    ? "H" : "",
                         (instr->rank) & RANK_LUNATIC ? "L" : "",
-                        !((instr->rank) & RANK_ID_4) ? "W" : "",
-                        !((instr->rank) & RANK_ID_5) ? "X" : "",
-                        !((instr->rank) & RANK_ID_6) ? "Y" : "",
-                        !((instr->rank) & RANK_ID_7) ? "Z" : "");
+                        !((instr->rank) & RANK_ID_4) ? "4" : "",
+                        !((instr->rank) & RANK_ID_5) ? "5" : "",
+                        !((instr->rank) & RANK_ID_6) ? "6" : "",
+                        !((instr->rank) & RANK_ID_7) ? "7" : "");
                 }
                 break;
             case THECL_INSTR_INSTR: {

--- a/util/list.c
+++ b/util/list.c
@@ -69,6 +69,16 @@ list_head(
         return NULL;
 }
 
+void*
+list_tail(
+    list_t* list)
+{
+    if (list->tail)
+        return list->tail->data;
+    else
+        return NULL;
+}
+
 int
 list_empty(
     list_t* list)

--- a/util/list.h
+++ b/util/list.h
@@ -51,6 +51,8 @@ list_t* list_new(void);
 list_node_t* list_node_new(void);
 /* Returns the data of head in the list. */
 void* list_head(list_t* list);
+/* Returns the data of tail in the list. */
+void* list_tail(list_t* list);
 /* Returns 1 if the list is empty. */
 int list_empty(list_t* list);
 /* Sets a node as the tail of the list. */


### PR DESCRIPTION
**New features** (th10+ only):
- difficulty switch expressions: `wait(60:50:40:30);` -> 

    ```cpp
    !E
      60;
    !N
      50;
    !H
      40;
    !LO /* in th10-th128 it's just !L */
      30;
    !*
      wait([-1]);
    ```
    last parameter always gets all remaining diffs, so do `10:20` to get just
    ```cpp
    !E
      10;
    !NHLO
      20;
    !*
    ```
    or `1:2:3:4:5` to split lunatic and overdrive (for games that have it)
    this only supports basic integer/float literals, putting variables/expressions inside will not work (I might add that later)
- no forced typecast for passing expressions to ins calls: basically now you don't have to do `wait(_S(2+2))`, `wait(2+2)` works just fine
- easy to write float literals that represent radians: `rad(180.0f)` -> `3.14159...f` (since this is just a way of representing a float value and not an actual function, you can't put variables/expressions in it)
- syntax for binary integer literals: `0b1001` -> `9`
- added forced sub calls by name - `@mySub();` compiles into `ins_11("mySub");`, even if no sub of that name exists in the current file (can also do `@mySub() async;` to use `ins_15` instead)
- declare variables anywhere in the sub and don't require `var;` at the beginning (ins_40 is prepended to the list in sub_finish automatically)
- declare & assign variables in 1 line with `var $myVar = 1;`
- automatically add ins_10 at the end of the sub if there is no ins_1/ins_10 present
- since 3 last features make thecl add instructions automatically, simple creation mode was added to disable them (pass `-s` in args when running thecl to enable this mode)
- added an error message when a variable with a duplicate name is declared
- added `times` loop known from some screenshots of ZUN's ECL:
    ```cpp
    times(10) {
      ins_whatever();
    }
    ```
    since the `times` loop requires one of the earlier features enabled to work (as it automatically creates a counter variable), it's not available in simple creation mode

**Fixes**:
- fixed passing expressions to sub calls by name - expression_output wasn't called and the expressions ended up being compiled AFTER the call instead
- fixed sub calls by name without any parameters (earlier it would call list_free_nodes with a NULL pointer, which crashed thecl)
- fixed some minor issues where syntax wouldn't get accepted (`break;` no longer requires an instruction before it, rank flags don't require an instruction after them etc)
- fixed pre-th10 unused difficulty flag dumping (dump `!457` instead of `!XYZ`)