### PR TITLE
thecl: better float and rad value handling

### DIFF
--- a/thecl/ecsparse.y
+++ b/thecl/ecsparse.y
@@ -168,6 +168,7 @@ static void directive_eclmap(parser_state_t* state, char* name);
 %token <string> IDENTIFIER "identifier"
 %token <string> TEXT "text"
 %token <integer> INTEGER "integer"
+%token <integer> PLUS_INTEGER "+integer"
 %token <floating> FLOATING "floating"
 %token <string> RANK "rank"
 %token <string> DIRECTIVE "directive"
@@ -503,7 +504,7 @@ ArgumentDeclaration:
 
 Instructions:
     | Instructions INTEGER ":" { set_time(state, $2); }
-    | Instructions "+" INTEGER ":" { set_time(state, state->instr_time + $3) }
+    | Instructions PLUS_INTEGER ":" { set_time(state, state->instr_time + $2) }
     | Instructions IDENTIFIER ":" { label_create(state, $2); free($2); }
     | Instructions Instruction ";"
     | Instructions Block
@@ -1198,6 +1199,10 @@ Address_Type:
 
 Integer:
     INTEGER {
+        $$ = param_new('S');
+        $$->value.val.S = $1;
+      }
+    | PLUS_INTEGER {
         $$ = param_new('S');
         $$->value.val.S = $1;
       }

--- a/thecl/ecsscan.l
+++ b/thecl/ecsscan.l
@@ -134,11 +134,11 @@ _Sf return CAST_IF;
 _ff return CAST_FF;
 _fS return CAST_FI;
 
--?[0-9]+(\.[0-9]*)?f {
+-|\+?[0-9]+(\.([0-9]*f|[0-9]+)|f) {
     yylval.floating = strtof(yytext, NULL);
     return FLOATING;
 }
-rad\(-?[0-9]+(\.[0-9]*)?f\) {
+rad\((-|\+)?[0-9]+(\.([0-9]*f|[0-9]+)|f)?\) {
     yylval.floating = strtof(yytext+4, NULL) / 180.0f * 3.14159265359f;
     return FLOATING;
 }
@@ -146,15 +146,15 @@ ins_[0-9]+ {
     yylval.integer = strtol(yytext + 4, NULL, 10);
     return INSTRUCTION;
 }
--?[0-9]+ {
+-|\+?[0-9]+ {
     yylval.integer = strtol(yytext, NULL, 10);
     return INTEGER;
 }
--?0x[0-9a-fA-F]+ {
+-|\+?0x[0-9a-fA-F]+ {
     yylval.integer = strtol(yytext, NULL, 16);
     return INTEGER;
 }
--?0b[0-1]+ {
+-|\+?0b[0-1]+ {
     bool isNegative = yytext[0] == '-';
     yylval.integer = strtol(yytext + (isNegative ? 3 : 2), NULL, 2);
     if (isNegative) yylval.integer = -yylval.integer;

--- a/thecl/ecsscan.l
+++ b/thecl/ecsscan.l
@@ -138,7 +138,7 @@ _fS return CAST_FI;
     yylval.floating = strtof(yytext, NULL);
     return FLOATING;
 }
-rad\((-|\+)?[0-9]+(\.([0-9]*f|[0-9]+)|f)\) {
+rad\((-|\+)?[0-9]+(\.([0-9]*f|[0-9]+)|f)?\) {
     yylval.floating = strtof(yytext+4, NULL) / 180.0f * 3.14159265359f;
     return FLOATING;
 }

--- a/thecl/ecsscan.l
+++ b/thecl/ecsscan.l
@@ -134,11 +134,11 @@ _Sf return CAST_IF;
 _ff return CAST_FF;
 _fS return CAST_FI;
 
--|\+?[0-9]+(\.([0-9]*f|[0-9]+)|f) {
+(-|\+)?[0-9]+(\.([0-9]*f|[0-9]+)|f) {
     yylval.floating = strtof(yytext, NULL);
     return FLOATING;
 }
-rad\((-|\+)?[0-9]+(\.([0-9]*f|[0-9]+)|f)?\) {
+rad\((-|\+)?[0-9]+(\.([0-9]*f|[0-9]+)|f)\) {
     yylval.floating = strtof(yytext+4, NULL) / 180.0f * 3.14159265359f;
     return FLOATING;
 }
@@ -146,9 +146,13 @@ ins_[0-9]+ {
     yylval.integer = strtol(yytext + 4, NULL, 10);
     return INSTRUCTION;
 }
--|\+?[0-9]+ {
+-?[0-9]+ {
     yylval.integer = strtol(yytext, NULL, 10);
     return INTEGER;
+}
+\+[0-9]+ {
+    yylval.integer = strtol(yytext, NULL, 10);
+    return PLUS_INTEGER;
 }
 -|\+?0x[0-9a-fA-F]+ {
     yylval.integer = strtol(yytext, NULL, 16);


### PR DESCRIPTION
thecl does not make the distinction between doubles and singles (one can be added later, like with D or something), and ZUN's ECL engine (almost?) exclusively uses singles. Therefore, values like "1.23" should be recognized as floats, NOT doubles (which, once again, thecl doesn't even know about). Also adds support for values like "+12" and allows integers in the rad() function.