### PR TITLE
new eclmap format

### DIFF
--- a/contrib/eclmapcvt.awk
+++ b/contrib/eclmapcvt.awk
@@ -1,0 +1,48 @@
+#!/usr/bin/awk -f
+BEGIN {
+	FS="[ \t\r]"
+	#cs = "!ins_names"
+	s["?"] = "!ins_names"
+	s["$"] = "!gvar_names"
+	s["%"] = "!gvar_names"
+	s["@"] = "!timeline_ins_names"
+}
+#{print "["$0"]", "["$1"]", "["$2"]", "["$3"]"}
+NR == 1 {
+	if ($0 == "eclmap") {
+		print "!eclmap"
+		next
+	} else {
+		print "ERROR: this isn't an old-style eclmap" > "/dev/stderr"
+		exit 1
+	}
+}
+/^[ \t\r]*#/ || NF == 0 {
+	print
+	next
+}
+{
+	if (NF < 3) {
+		print "#FIXME#", $0
+		print "WARN: Garbage on line", NR > "/dev/stderr"
+		next
+	}
+	if ($1 !~ /^(-?[1-9][0-9]*|0)$/) {
+		print "WARN: opcode `"$1"'is not numeric, line", NR > "/dev/stderr"
+	}
+	if ($3 !~ /^[A-Za-z_][0-9A-Za-z_]*$/ || $3 ~ /^ins_/) {
+		print "WARN: identificator `"$3"' is invalid, line", NR > "/dev/stderr"
+	}
+	if (s[$2] == "") {
+		print "#FIXME#", $0
+		print "WARN: unknown signature on line", NR > "/dev/stderr"
+	} else {
+		if (s[$2] != cs) {
+			print (cs=s[$2])
+		}
+		num = $1
+		$1 = $2 = ""
+		print num,substr($0,3)
+	}
+	next
+}

--- a/contrib/eclmapcvt.awk
+++ b/contrib/eclmapcvt.awk
@@ -9,7 +9,7 @@ BEGIN {
 }
 #{print "["$0"]", "["$1"]", "["$2"]", "["$3"]"}
 NR == 1 {
-	if ($0 == "eclmap") {
+	if ($1 == "eclmap") {
 		print "!eclmap"
 		next
 	} else {

--- a/thecl/CMakeLists.txt
+++ b/thecl/CMakeLists.txt
@@ -5,8 +5,8 @@ flex_target(EcsScan ecsscan.l ${CMAKE_CURRENT_BINARY_DIR}/ecsscan.c)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR})
 add_executable(thecl
   ${BISON_EcsParse_OUTPUT_SOURCE} ${FLEX_EcsScan_OUTPUTS}
-  expr.c thecl.c eclmap.c path.c thecl06.c thecl10.c
-  expr.h thecl.h eclmap.h path.h)
+  expr.c thecl.c seqmap.c eclmap.c path.c thecl06.c thecl10.c
+  expr.h thecl.h seqmap.h eclmap.h path.h)
 if(WIN32)
     set(ADDITIONAL_LIBRARIES "")
 else()

--- a/thecl/eclmap.c
+++ b/thecl/eclmap.c
@@ -178,8 +178,10 @@ validate_signature(
     int linenum,
     const char *value)
 {
-    fprintf(stderr, "%s:%s:%u: warning: signature mapping is not yet implemented\n", argv0, state->fn, linenum);
-    return 1;
+    static int warned = 0;
+    if (!warned && ++warned)
+        fprintf(stderr, "%s:%s:%u: warning: signature validation is not yet implemented\n", argv0, state->fn, linenum);
+    return 0;
 }
 
 static int

--- a/thecl/ecsparse.y
+++ b/thecl/ecsparse.y
@@ -457,12 +457,8 @@ Statement:
                     ++s;
                 }
                 buf[s] = '\0';
-                char* format = malloc(strlen(buf) + 1);
-                strcpy(format, buf);
-                id_format_pair_t* fmt = malloc(sizeof(id_format_pair_t));
-                fmt->id = id;
-                fmt->format = format;
-                list_append_new(g_user_fmts, fmt);
+                seqmap_entry_t ent = { id, buf };
+                seqmap_set(g_eclmap->ins_signatures, &ent);
             } else {
                 yyerror(state, "#ins: specified format is too long");
             }

--- a/thecl/ecsparse.y
+++ b/thecl/ecsparse.y
@@ -432,7 +432,8 @@ Statement:
             directive_eclmap(state, $2);
         } else if (strcmp($1, "nowarn") == 0) {
             state->ecl->no_warn = (strcmp($2, "true") == 0);
-        } else if (strcmp($1, "ins") == 0) {
+        } else if (strcmp($1, "ins") == 0 || strcmp($1, "timeline_ins") == 0) {
+            int is_timeline = ($1)[0] == 't';
             if (strlen($2) < 256) {
                 /* arg format: "id format", e.g. "200 SSff" */
                 char* arg = $2;
@@ -458,7 +459,7 @@ Statement:
                 }
                 buf[s] = '\0';
                 seqmap_entry_t ent = { id, buf };
-                seqmap_set(g_eclmap->ins_signatures, &ent);
+                seqmap_set(is_timeline ? g_eclmap->timeline_ins_signatures : g_eclmap->ins_signatures, &ent);
             } else {
                 yyerror(state, "#ins: specified format is too long");
             }

--- a/thecl/seqmap.c
+++ b/thecl/seqmap.c
@@ -1,0 +1,189 @@
+/*
+ * Redistribution and use in source and binary forms, with
+ * or without modification, are permitted provided that the
+ * following conditions are met:
+ *
+ * 1. Redistributions of source code must retain this list
+ *    of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce this
+ *    list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the
+ *    distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ * CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+ * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+#include <config.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <string.h>
+#include <stdlib.h>
+#include <errno.h>
+#include "seqmap.h"
+#include "program.h"
+#include "util.h"
+
+void
+seqmap_free(
+    seqmap_t* map)
+{
+    seqmap_entry_t* ent;
+
+    if (!map) return;
+
+    list_for_each(map, ent) {
+        if (ent && ent->flags & SEQMAP_FLAG_ALLOC) {
+            if (ent) {
+                free(ent->value);
+            }
+            free(ent);
+        }
+    }
+
+    list_free_nodes(map);
+
+    free(map);
+}
+
+/* Allocates new seqmap entry, appends it to a seqmap, and returns it */
+static seqmap_entry_t*
+seqmap_append_new(
+    seqmap_t* map,
+    int key)
+{
+    seqmap_entry_t* ent = malloc(sizeof(seqmap_entry_t));
+    ent->key = key;
+    ent->value = NULL;
+    ent->flags = SEQMAP_FLAG_ALLOC;
+    list_append_new(map, ent);
+    return ent;
+}
+
+void
+seqmap_set(
+    seqmap_t* map,
+    const seqmap_entry_t* ent1)
+{
+    seqmap_entry_t* ent2;
+    list_for_each(map, ent2) {
+        if (ent2 && ent2->key == ent1->key) {
+            break;
+        }
+    }
+
+    if (!ent2) {
+        ent2 = seqmap_append_new(map, ent1->key);
+    }
+
+    free(ent2->value);
+    ent2->value = ent1->value ? strdup(ent1->value) : NULL;
+}
+
+seqmap_entry_t*
+seqmap_get(
+    seqmap_t* map,
+    int key)
+{
+    seqmap_entry_t* ent;
+    list_for_each(map, ent) {
+        if (ent && ent->key == key) {
+            break;
+        }
+    }
+    return ent;
+}
+
+seqmap_entry_t*
+seqmap_find(
+    seqmap_t* map,
+    const char* value)
+{
+    seqmap_entry_t* ent;
+    list_for_each(map, ent) {
+        if (ent && ent->value && !strcmp(ent->value, value)) {
+            break;
+        }
+    }
+    return ent;
+}
+
+void
+seqmap_load(
+    const char* magic,
+    void *state,
+    seqmap_setfunc_t set,
+    seqmap_controlfunc_t control,
+    FILE* f,
+    const char* fn)
+{
+    static char buffer[512];
+
+    if (!fgets(buffer, sizeof(buffer), f)) {
+        fprintf(stderr, "%s:%s: couldn't read the first line\n",argv0,fn);
+        return;
+    }
+
+    if (strncmp(buffer, magic, strlen(magic))) {
+        fprintf(stderr, "%s:%s:1: invalid magic\n",argv0,fn);
+        return;
+    }
+
+    int linecount = 1;
+    while (fgets(buffer, sizeof(buffer), f)) {
+        char *ptr, *ptrend;
+        seqmap_entry_t ent;
+
+        ++linecount;
+
+        /* remove the comments */
+        ptr = strchr(buffer, '#');
+        if (ptr)
+            *ptr = '\0';
+
+        /* parse key */
+        ptr = strtok(buffer, " \t\r\n");
+        if (!ptr)
+            continue; /* 0 tokens -> empty line, no need to error */
+
+        if (ptr[0] == '!') {
+            control(state, linecount, ptr);
+            continue;
+        }
+
+        errno = 0;
+        ent.key = strtol(ptr, &ptrend, 0);
+        if (ptr == ptrend || errno != 0) {
+            fprintf(stderr, "%s:%s:%u: key token is not a number\n",argv0,fn,linecount);
+            continue;
+        }
+
+        /* parse value */
+        ptr = strtok(NULL, " \t\r\n");
+        if (!ptr) {
+            fprintf(stderr, "%s:%s:%u: not enough tokens\n",argv0,fn,linecount);
+            continue;
+        }
+
+        /* validate value */
+        if (ptr[0] == '_' && ptr[1] == '\0') {
+            ptr[0] = '\0'; /* allow empty strings to be specified with "_" */
+        }
+        ent.value = ptr;
+
+        set(state, linecount, &ent);
+    }
+}

--- a/thecl/seqmap.c
+++ b/thecl/seqmap.c
@@ -39,9 +39,9 @@
 
 void
 seqmap_free(
-    seqmap_t* map)
+    seqmap_t *map)
 {
-    seqmap_entry_t* ent;
+    seqmap_entry_t *ent;
 
     if (!map) return;
 
@@ -59,46 +59,36 @@ seqmap_free(
     free(map);
 }
 
-/* Allocates new seqmap entry, appends it to a seqmap, and returns it */
-static seqmap_entry_t*
-seqmap_append_new(
-    seqmap_t* map,
+/* Allocates new seqmap entry, prepends it to a seqmap, and returns it */
+static seqmap_entry_t *
+seqmap_prepend_new(
+    seqmap_t *map,
     int key)
 {
-    seqmap_entry_t* ent = malloc(sizeof(seqmap_entry_t));
+    seqmap_entry_t *ent = malloc(sizeof(seqmap_entry_t));
     ent->key = key;
     ent->value = NULL;
     ent->flags = SEQMAP_FLAG_ALLOC;
-    list_append_new(map, ent);
+    list_prepend_new(map, ent);
     return ent;
 }
 
 void
 seqmap_set(
-    seqmap_t* map,
-    const seqmap_entry_t* ent1)
+    seqmap_t *map,
+    const seqmap_entry_t *ent1)
 {
-    seqmap_entry_t* ent2;
-    list_for_each(map, ent2) {
-        if (ent2 && ent2->key == ent1->key) {
-            break;
-        }
-    }
+    seqmap_entry_t *ent2 = seqmap_prepend_new(map, ent1->key);
 
-    if (!ent2) {
-        ent2 = seqmap_append_new(map, ent1->key);
-    }
-
-    free(ent2->value);
     ent2->value = ent1->value ? strdup(ent1->value) : NULL;
 }
 
-seqmap_entry_t*
+seqmap_entry_t *
 seqmap_get(
-    seqmap_t* map,
+    seqmap_t *map,
     int key)
 {
-    seqmap_entry_t* ent;
+    seqmap_entry_t *ent;
     list_for_each(map, ent) {
         if (ent && ent->key == key) {
             break;
@@ -109,10 +99,10 @@ seqmap_get(
 
 seqmap_entry_t*
 seqmap_find(
-    seqmap_t* map,
-    const char* value)
+    seqmap_t *map,
+    const char *value)
 {
-    seqmap_entry_t* ent;
+    seqmap_entry_t *ent;
     list_for_each(map, ent) {
         if (ent && ent->value && !strcmp(ent->value, value)) {
             break;
@@ -123,12 +113,12 @@ seqmap_find(
 
 void
 seqmap_load(
-    const char* magic,
+    const char *magic,
     void *state,
     seqmap_setfunc_t set,
     seqmap_controlfunc_t control,
-    FILE* f,
-    const char* fn)
+    FILE *f,
+    const char *fn)
 {
     static char buffer[512];
 

--- a/thecl/seqmap.h
+++ b/thecl/seqmap.h
@@ -57,14 +57,14 @@ typedef int (*seqmap_controlfunc_t)(
 /* Allocates and initalizes a new seqmap */
 #define seqmap_new() ((seqmap_t*)list_new())
 /* Frees a seqmap */
-void seqmap_free(seqmap_t* map);
+void seqmap_free(seqmap_t *map);
 /* Sets an entry in a seqmap */
-void seqmap_set(seqmap_t* map, const seqmap_entry_t* ent);
+void seqmap_set(seqmap_t *map, const seqmap_entry_t *ent);
 /* Finds an entry in a seqmap by key */
-seqmap_entry_t* seqmap_get(seqmap_t* map, int key);
+seqmap_entry_t *seqmap_get(seqmap_t *map, int key);
 /* Finds an entry in a seqmap by value */
-seqmap_entry_t* seqmap_find(seqmap_t* map, const char* value);
+seqmap_entry_t *seqmap_find(seqmap_t *map, const char *value);
 /* Loads entries from seqmap file (thread unsafe) */
-void seqmap_load(const char* magic, void* state, seqmap_setfunc_t set, seqmap_controlfunc_t control, FILE* f, const char* fn);
+void seqmap_load(const char *magic, void *state, seqmap_setfunc_t set, seqmap_controlfunc_t control, FILE *f, const char *fn);
 
 #endif

--- a/thecl/seqmap.h
+++ b/thecl/seqmap.h
@@ -27,29 +27,44 @@
  * DAMAGE.
  */
 
-#ifndef ECLMAP_H_
-#define ECLMAP_H_
+#ifndef SEQMAP_H_
+#define SEQMAP_H_
 
 #include <config.h>
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdio.h>
-#include "seqmap.h"
+#include "list.h"
 
-typedef struct eclmap_t {
-    seqmap_t *ins_names;
-    seqmap_t *ins_signatures;
-    seqmap_t *gvar_names;
-    seqmap_t *gvar_types;
-    seqmap_t *timeline_ins_names;
-    seqmap_t *timeline_ins_signatures;
-} eclmap_t;
+#define SEQMAP_FLAG_ALLOC (1<<0)
+typedef struct seqmap_entry_t {
+    int key;
+    char *value;
+    int flags;
+} seqmap_entry_t;
 
-/* Allocates and initalizes a new eclmap */
-eclmap_t* eclmap_new();
-/* Frees an eclmap */
-void eclmap_free(eclmap_t* map);
-/* Loads entries from eclmap file (thread unsafe) */
-void eclmap_load(unsigned int version, eclmap_t* emap, FILE* f, const char* fn);
+typedef list_t seqmap_t;
+
+typedef int (*seqmap_setfunc_t)(
+    void *state,
+    int linenum,
+    const seqmap_entry_t *ent);
+typedef int (*seqmap_controlfunc_t)(
+    void *state,
+    int linenum,
+    const char *cline);
+
+/* Allocates and initalizes a new seqmap */
+#define seqmap_new() ((seqmap_t*)list_new())
+/* Frees a seqmap */
+void seqmap_free(seqmap_t* map);
+/* Sets an entry in a seqmap */
+void seqmap_set(seqmap_t* map, const seqmap_entry_t* ent);
+/* Finds an entry in a seqmap by key */
+seqmap_entry_t* seqmap_get(seqmap_t* map, int key);
+/* Finds an entry in a seqmap by value */
+seqmap_entry_t* seqmap_find(seqmap_t* map, const char* value);
+/* Loads entries from seqmap file (thread unsafe) */
+void seqmap_load(const char* magic, void* state, seqmap_setfunc_t set, seqmap_controlfunc_t control, FILE* f, const char* fn);
 
 #endif

--- a/thecl/thecl.1
+++ b/thecl/thecl.1
@@ -24,7 +24,7 @@
 .\" OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 .\" SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
 .\" DAMAGE.
-.Dd October 27, 2019
+.Dd October 31, 2019
 .Dt THECL 1
 .Os thtk
 .Sh NAME
@@ -77,6 +77,77 @@ Running the program without a command will list the supported formats.
 The
 .Nm
 utility exits with 0 on success, 1 on error.
+.Sh "ECLMAP FILE FORMAT"
+Eclmap files, which are added with the
+.Fl m
+option, consist of two kinds of lines: control lines (which start with
+.Ql \&! Ns
+), and mapping lines.
+.Pp
+The file starts with
+.Ql !eclmap
+control line. The rest of the control lines select the mapping that is being modified:
+.Bl -tag -width Ds
+.It Ql !ins_names
+Instruction names. This is the default mapping.
+.br
+Value: identifier
+.It Ql !ins_signatures
+Instruction signatures.
+.br
+Value: signature
+.It Ql !gvar_names
+Global variable names.
+.br
+Value: identifier
+.It Ql !gvar_types
+Global variable types.
+.br
+.No Value: type ( Ns
+.Ql $
+for integer,
+.Ql %
+for float)
+.It Ql !timeline_ins_names
+Timeline instruction names.
+.br
+Value: identifier
+.It Ql !timeline_ins_signatures
+Timeline instruction signatures.
+.br
+Value: signature
+.El
+.Pp
+Mapping lines are always of form
+.D1 Oo Ar key Oc Oo Ar value Oc
+where
+.Ar key
+is an integer, and
+.Ar value
+is a string without spaces.
+.Ql _
+.Ns can be used to specify an empty value (useful for signatures without arguments).
+.Pp
+When multiple mappings are specified for the same key or value, the most recent one has priority. For example:
+.Bd -literal -offset indent
+123 foo
+123 bar
+.Ed
+.Pp
+will map
+.Ql 123
+to
+.Ql bar Ns
+,
+.Ql bar
+to
+.Ql 123 Ns
+, and
+.Ql foo
+to
+.Ql 123 Ns
+\&.
+Note how the reverse mapping doesn't get overridden.
 .\" TODO: .Sh EXAMPLES
 .Sh SEE ALSO
 .Lk https://github.com/thpatch/thtk "Project homepage"

--- a/thecl/thecl.c
+++ b/thecl/thecl.c
@@ -40,9 +40,7 @@ extern const thecl_module_t th06_ecl;
 extern const thecl_module_t th10_ecl;
 
 list_t* g_user_fmts = NULL;
-eclmap_t* g_eclmap_opcode = NULL;
-eclmap_t* g_eclmap_timeline_opcode = NULL;
-eclmap_t* g_eclmap_global = NULL;
+eclmap_t *g_eclmap = NULL;
 bool g_ecl_rawoutput = false;
 bool g_ecl_simplecreate = false;
 bool g_was_error = false;
@@ -220,9 +218,7 @@ label_time(
 static void
 free_globals(void)
 {
-    eclmap_free(g_eclmap_opcode);
-    eclmap_free(g_eclmap_timeline_opcode);
-    eclmap_free(g_eclmap_global);
+    eclmap_free(g_eclmap);
     id_format_pair_t* fmt;
     list_for_each(g_user_fmts, fmt) {
         free(fmt->format);
@@ -280,9 +276,7 @@ main(int argc, char* argv[])
     current_input = "(stdin)";
     current_output = "(stdout)";
 
-    g_eclmap_opcode = eclmap_new();
-    g_eclmap_timeline_opcode = eclmap_new();
-    g_eclmap_global = eclmap_new();
+    g_eclmap = eclmap_new();
     g_user_fmts = list_new();
     atexit(free_globals);
 
@@ -310,7 +304,7 @@ main(int argc, char* argv[])
                     argv0, util_optarg, strerror(errno));
                 exit(1);
             }
-            eclmap_load(version, g_eclmap_opcode, g_eclmap_timeline_opcode, g_eclmap_global, map_file, util_optarg);
+            eclmap_load(version, g_eclmap, map_file, util_optarg);
             fclose(map_file);
             break;
         }

--- a/thecl/thecl.c
+++ b/thecl/thecl.c
@@ -39,7 +39,6 @@
 extern const thecl_module_t th06_ecl;
 extern const thecl_module_t th10_ecl;
 
-list_t* g_user_fmts = NULL;
 eclmap_t *g_eclmap = NULL;
 bool g_ecl_rawoutput = false;
 bool g_ecl_simplecreate = false;
@@ -219,13 +218,6 @@ static void
 free_globals(void)
 {
     eclmap_free(g_eclmap);
-    id_format_pair_t* fmt;
-    list_for_each(g_user_fmts, fmt) {
-        free(fmt->format);
-        free(fmt);
-    }
-    list_free_nodes(g_user_fmts);
-    free(g_user_fmts);
 }
 
 bool
@@ -277,7 +269,6 @@ main(int argc, char* argv[])
     current_output = "(stdout)";
 
     g_eclmap = eclmap_new();
-    g_user_fmts = list_new();
     atexit(free_globals);
 
     argv0 = util_shortname(argv[0]);

--- a/thecl/thecl.h
+++ b/thecl/thecl.h
@@ -248,9 +248,7 @@ extern FILE* yyin;
 extern int yyparse(parser_state_t*);
 
 extern list_t* g_user_fmts;
-extern eclmap_t* g_eclmap_opcode;
-extern eclmap_t* g_eclmap_timeline_opcode;
-extern eclmap_t* g_eclmap_global;
+extern eclmap_t* g_eclmap;
 extern bool g_ecl_rawoutput;
 extern bool g_ecl_simplecreate;
 extern bool g_was_error;

--- a/thecl/thecl.h
+++ b/thecl/thecl.h
@@ -247,7 +247,6 @@ typedef struct {
 extern FILE* yyin;
 extern int yyparse(parser_state_t*);
 
-extern list_t* g_user_fmts;
 extern eclmap_t* g_eclmap;
 extern bool g_ecl_rawoutput;
 extern bool g_ecl_simplecreate;

--- a/thecl/thecl06.c
+++ b/thecl/thecl06.c
@@ -811,10 +811,9 @@ th06_find_format(
 {
     if (is_timeline) return th06_find_timeline_format(version, id);
 
-    id_format_pair_t* fmt;
-    list_for_each(g_user_fmts, fmt) {
-        if (fmt->id == id) return fmt->format;
-    }
+    seqmap_entry_t *ent = seqmap_get(g_eclmap->ins_signatures, id);
+    if (ent)
+        return ent->value;
 
     const char* ret = NULL;
 

--- a/thecl/thecl06.c
+++ b/thecl/thecl06.c
@@ -200,9 +200,9 @@ th06_stringify_param(
                 else if (param->value.type == 'f') val = floor(param->value.val.f);
                 else val = param->value.val.s;
                 
-                eclmap_entry_t* ent = eclmap_get(g_eclmap_global, val);
-                if (ent && ent->mnemonic) {
-                    snprintf(temp, 256, "%c%s", param->value.type == 'f' ? '%' : '$', ent->mnemonic);
+                seqmap_entry_t* ent = seqmap_get(g_eclmap->gvar_names, val);
+                if (ent) {
+                    snprintf(temp, 256, "%c%s", param->value.type == 'f' ? '%' : '$', ent->value);
                     return strdup(temp);
                 }
             }
@@ -1168,9 +1168,9 @@ th06_dump(
                 fprintf(out, "%s_%u:\n", sub->name, instr->offset);
                 break;
             case THECL_INSTR_INSTR: {
-                eclmap_entry_t *ent = eclmap_get(g_eclmap_opcode, instr->id);
-                if(ent && ent->mnemonic) {
-                    fprintf(out, "    %s(", ent->mnemonic);
+                seqmap_entry_t *ent = seqmap_get(g_eclmap->ins_names, instr->id);
+                if (ent) {
+                    fprintf(out, "    %s(", ent->value);
                 }
                 else {
                     fprintf(out, "    ins_%u(", instr->id);
@@ -1229,9 +1229,9 @@ th06_dump(
                 }
                 break;
             case THECL_INSTR_INSTR: {
-                eclmap_entry_t *ent = eclmap_get(g_eclmap_timeline_opcode, instr->id);
-                if(ent && ent->mnemonic)
-                    fprintf(out, "    %s(", ent->mnemonic);
+                seqmap_entry_t *ent = seqmap_get(g_eclmap->timeline_ins_names, instr->id);
+                if (ent)
+                    fprintf(out, "    %s(", ent->value);
                 else
                     fprintf(out, "    ins_%u(", instr->id);
 

--- a/thecl/thecl06.c
+++ b/thecl/thecl06.c
@@ -1555,7 +1555,7 @@ th06_compile(
         thecl_instr_t* instr;
         list_for_each(&sub->instrs, instr) {
             th06_instr_t* raw_instr = th06_instr_serialize(ecl, sub, instr);
-			file_write(out, raw_instr, raw_instr->size);
+            file_write(out, raw_instr, raw_instr->size);
             if (raw_instr->id > max_opcode) {
                 fprintf(stderr, "%s: warning: opcode: id %hu was higher than the maximum %hu\n", argv0, raw_instr->id, max_opcode);
             }

--- a/thecl/thecl06.c
+++ b/thecl/thecl06.c
@@ -266,6 +266,10 @@ th06_find_timeline_format(
     unsigned int version,
     unsigned int id)
 {
+    seqmap_entry_t *ent = seqmap_get(g_eclmap->timeline_ins_signatures, id);
+    if (ent)
+        return ent->value;
+
     const char* ret = NULL;
 
     switch(version) {

--- a/thecl/thecl10.c
+++ b/thecl/thecl10.c
@@ -1992,7 +1992,7 @@ th10_instr_serialize(
                             argv0, sub->name, sub_name);
                     break;
                  } else if (
-				    format[v] != '?' &&
+                    format[v] != '?' &&
                     (((D[0] == 0x6969 || D[0] == 0x6966) && format[v] == 'f') ||
                     ((D[0] == 0x6669 || D[0] == 0x6666) && format[v] == 'S'))
                 ) {
@@ -2130,17 +2130,17 @@ th10_compile(
     if (pos % 4 != 0)
         file_seek(out, pos + 4 - pos % 4);
 
-	uint16_t max_opcode;
-	/* TODO: Get max opcodes for the rest of the games */
-	switch (ecl->version)
-	{
-	case 14:
-		max_opcode = 1003;
-		break;
-	default:
-		max_opcode = 0xFFFFU;
-		break;
-	}
+    uint16_t max_opcode;
+    /* TODO: Get max opcodes for the rest of the games */
+    switch (ecl->version)
+    {
+    case 14:
+        max_opcode = 1003;
+        break;
+    default:
+        max_opcode = 0xFFFFU;
+        break;
+    }
 
     list_for_each(&ecl->subs, sub) {
         if (sub->forward_declaration || sub->is_inline)
@@ -2152,9 +2152,9 @@ th10_compile(
             return 0;
 
         list_for_each(&sub->instrs, instr) {
-			if (instr->id > max_opcode) {
-				fprintf(stderr, "%s: warning: opcode: id %hu was higher than the maximum %hu\n", argv0, instr->id, max_opcode);
-			}
+            if (instr->id > max_opcode) {
+                fprintf(stderr, "%s: warning: opcode: id %hu was higher than the maximum %hu\n", argv0, instr->id, max_opcode);
+            }
             unsigned char* data = th10_instr_serialize(ecl->version, sub, instr, &ecl->subs, ecl->no_warn);
             if (!file_write(out, data, instr->size))
                 return 0;

--- a/thecl/thecl10.c
+++ b/thecl/thecl10.c
@@ -1529,9 +1529,9 @@ th10_stringify_param(
         } else {
             if (param->stack && (param->value.type == 'f' || param->value.type == 'S')) {
                 int val = param->value.type == 'f' ? floor(param->value.val.f) : param->value.val.S;
-                eclmap_entry_t* ent = eclmap_get(g_eclmap_global, val);
-                if (ent && ent->mnemonic) {
-                    sprintf(temp, "%c%s", param->value.type == 'f' ? '%' : '$', ent->mnemonic);
+                seqmap_entry_t* ent = seqmap_get(g_eclmap->gvar_names, val);
+                if (ent) {
+                    sprintf(temp, "%c%s", param->value.type == 'f' ? '%' : '$', ent->value);
                     return strdup(temp);
                 }
             }
@@ -1639,9 +1639,9 @@ th10_stringify_instr(
             free(async_id_str);
         }
      } else {
-        eclmap_entry_t *ent = eclmap_get(g_eclmap_opcode, instr->id);
-        if(ent && ent->mnemonic) {
-            sprintf(string, "%s(", ent->mnemonic);
+        seqmap_entry_t *ent = seqmap_get(g_eclmap->ins_names, instr->id);
+        if (ent) {
+            sprintf(string, "%s(", ent->value);
         }
         else {
             sprintf(string, "ins_%u(", instr->id);

--- a/thecl/thecl10.c
+++ b/thecl/thecl10.c
@@ -1004,10 +1004,9 @@ th10_find_format(
 {
     if (is_timeline) return NULL;
 
-    id_format_pair_t* fmt;
-    list_for_each(g_user_fmts, fmt) {
-        if (fmt->id == id) return fmt->format;
-    }
+    seqmap_entry_t *ent = seqmap_get(g_eclmap->ins_signatures, id);
+    if (ent)
+        return ent->value;
 
     const char* ret = NULL;
 


### PR DESCRIPTION
Convert with `awk -f contrib/eclmapcvt.awk old.map > new.map`

Documentation from manpage
```
ECLMAP FILE FORMAT
     Eclmap files, which are added with the -m option,
     consist of two kinds of lines: control lines (which
     start with ‘!’), and mapping lines.

     The file starts with ‘!eclmap’ control line. The rest
     of the control lines select the mapping that is being
     modified:

     ‘!ins_names’
             Instruction names. This is the default map‐
             ping.
             Value: identifier

     ‘!ins_signatures’
             Instruction signatures.
             Value: signature

     ‘!gvar_names’
             Global variable names.
             Value: identifier

     ‘!gvar_types’
             Global variable types.
             Value: type (‘$’ for integer, ‘%’ for float)

     ‘!timeline_ins_names’
             Timeline instruction names.
             Value: identifier

     ‘!timeline_ins_signatures’
             Timeline instruction signatures.
             Value: signature

     Mapping lines are always of form
           [key] [value]
     where key is an integer, and value is a string with‐
     out spaces.  ‘_’ can be used to specify an empty
     value (useful for signatures without arguments).

     When multiple mappings are specified for the same key
     or value, the most recent one has priority. For exam‐
     ple:

           123 foo
           123 bar

     will map ‘123’ to ‘bar’, ‘bar’ to ‘123’, and ‘foo’ to
     ‘123’.  Note how the reverse mapping doesn't get
     overridden.
```

Someone please check that everything works