### PR TITLE
reduce/reduce conflicts and precedence fixes

### DIFF
--- a/thecl/ecsparse.y
+++ b/thecl/ecsparse.y
@@ -1237,7 +1237,8 @@ Expression:
     /* Custom expressions. */
     | IDENTIFIER "(" Instruction_Parameters ")"          { $$ = expression_call_new(state, $3, $1); }
     | Rank_Switch_List            { $$ = expression_rank_switch_new(state, $1); }
-    | Expression "?" Expression_Safe ":" Expression_Safe { $$ = expression_ternary_new(state, $1, $3, $5); }
+    | Expression "?" Expression_Safe ":" Expression_Safe  %prec QUESTION
+                                  { $$ = expression_ternary_new(state, $1, $3, $5); }
     ;
 
 /* 

--- a/thecl/ecsparse.y
+++ b/thecl/ecsparse.y
@@ -1161,18 +1161,6 @@ Instruction_Parameter:
         }
         param_free($2);
       }
-    | Cast_Target "(" Expression ")" {
-        list_prepend_new(&state->expressions, $3);
-
-        $$ = param_new($1);
-        $$->stack = 1;
-        $$->is_expression_param = $1;
-        if ($1 == 'S') {
-            $$->value.val.S = -1;
-        } else {
-            $$->value.val.f = -1.0f;
-        }
-      }
       | Expression {
           list_prepend_new(&state->expressions, $1);
 

--- a/thecl/ecsparse.y
+++ b/thecl/ecsparse.y
@@ -1143,9 +1143,7 @@ Cast_Type:
     ;
 
 Instruction_Parameter:
-      Address
-    | Integer
-    | Floating
+      Load_Type
     | Text
     | Cast_Target2 Cast_Type {
         $$ = param_new('D');

--- a/thecl/ecsparse.y
+++ b/thecl/ecsparse.y
@@ -326,8 +326,11 @@ static void directive_eclmap(parser_state_t* state, char* name);
 %type <integer> VarDeclaration
 
 %left QUESTION
-%left OR AND
-%left XOR B_OR B_AND
+%left OR
+%left AND
+%left B_OR
+%left XOR
+%left B_AND
 %left EQUAL INEQUAL
 %left LT LTEQ GT GTEQ
 %left ADD SUBTRACT

--- a/thecl/ecsparse.y
+++ b/thecl/ecsparse.y
@@ -860,9 +860,7 @@ SwitchBlock:
     ;
 
 CaseList:
-    Case
-    | Case Instructions
-    | CaseList Case
+    Case Instructions
     | CaseList Case Instructions
     ;
 

--- a/thecl/ecsparse.y
+++ b/thecl/ecsparse.y
@@ -332,9 +332,9 @@ static void directive_eclmap(parser_state_t* state, char* name);
 %left LT LTEQ GT GTEQ
 %left ADD SUBTRACT
 %left MULTIPLY DIVIDE MODULO
-%right NOT NEG
-%left SIN COS SQRT
-%right DEC
+%precedence NOT NEG
+%precedence SIN COS SQRT
+%precedence DEC
 
 %%
 

--- a/thecl/ecsparse.y
+++ b/thecl/ecsparse.y
@@ -342,6 +342,7 @@ static void directive_eclmap(parser_state_t* state, char* name);
 %%
 
 Statements:
+    %empty
     | Statements Statement
     ;
 
@@ -537,7 +538,7 @@ VarDeclaration:
     ;
 
 ArgumentDeclaration:
-    /* The | at the beginning is obviously intentional and needed to allow creating subs with no arguments. */
+    %empty
     | DeclareKeyword IDENTIFIER {
           var_create(state, state->current_sub, $2, $1);
           free($2);
@@ -549,6 +550,7 @@ ArgumentDeclaration:
     ;
 
 Instructions:
+    %empty
     | Instructions INTEGER ":" { set_time(state, $2); }
     | Instructions PLUS_INTEGER ":" { set_time(state, state->instr_time + $2); }
     | Instructions IDENTIFIER ":" { label_create(state, $2); free($2); }
@@ -650,6 +652,7 @@ IfBlock:
       ;
 
 ElseBlock:
+    %empty
     | "else"  {
           char labelstr[256];
           snprintf(labelstr, 256, "if_%i_%i", yylloc.first_line, yylloc.first_column);
@@ -1098,7 +1101,7 @@ Assignment:
 ;
 
 Instruction_Parameters:
-      { $$ = NULL; }
+    %empty { $$ = NULL; }
     | Instruction_Parameters_List
     ;
 

--- a/thecl/ecsparse.y
+++ b/thecl/ecsparse.y
@@ -290,7 +290,7 @@ static void directive_eclmap(parser_state_t* state, char* name);
 %token B_OR "|"
 %token B_AND "&"
 %token DEC "--"
-%token NEG "-"
+%token NEG
 %token NEGI
 %token NEGF
 %token SIN "sin"
@@ -1221,7 +1221,7 @@ Expression:
                                     if ($1->value.val.S >= 0) /* Stack variables only. This is also verrfied to be int by expression creation. */
                                         state->current_sub->vars[$1->value.val.S / 4]->is_written = true;
                                   }
-    | "-" Expression              {
+    | "-" Expression  %prec NEG   {
                                       if (is_post_th13(state->version)) {
                                           $$ = EXPR_21(NEGI, NEGF, $2);
                                       } else {

--- a/thecl/ecsscan.l
+++ b/thecl/ecsscan.l
@@ -124,7 +124,6 @@
 "|"        return B_OR;
 "&"        return B_AND;
 "--"       return DEC;
-"-"        return NEG;
 "sin"      return SIN;
 "cos"      return COS;
 "sqrt"     return SQRT;

--- a/thecl/expr.c
+++ b/thecl/expr.c
@@ -32,27 +32,6 @@
 #include "ecsparse.h"
 #include "expr.h"
 
-typedef struct {
-    int symbol;
-    int symbols[2];
-} alternative_t;
-
-static const alternative_t
-th10_alternatives[] = {
-    { ADD,      { ADDI, ADDF } },
-    { SUBTRACT, { SUBTRACTI, SUBTRACTF } },
-    { MULTIPLY, { MULTIPLYI, MULTIPLYF } },
-    { DIVIDE,   { DIVIDEI, DIVIDEF } },
-    { EQUAL,    { EQUALI, EQUALF } },
-    { INEQUAL,  { INEQUALI, INEQUALF } },
-    { LT,       { LTI, LTF } },
-    { LTEQ,     { LTEQI, LTEQF } },
-    { GT,       { GTI, GTF } },
-    { GTEQ,     { GTEQI, GTEQF } },
-    { NEG,      { NEGI, NEGF } },
-    { 0,        { 0, 0 } }
-};
-
 static const expr_t
 th10_expressions[] = {
     /* The program checks against the number of params, as well as the


### PR DESCRIPTION
The only remaining r/r conflicts are in the following places:
`IDENTIFIER "(" Instruction_Parameter • "," Instruction_Parameter • ")" • ";"`
- The first two are because `Instruction_Parameter` includes `Expression`, and both of them include `Load_Type`.
- The last one is because `Instruction` includes `Expression`, and both of them include `IDENTIFIER"(" Instruction_Parameters ")"`
Both of these are kinda hard to fix.