### PR TITLE
thdat: remove unused include

### DIFF
--- a/thtk/thdat.c
+++ b/thtk/thdat.c
@@ -33,7 +33,6 @@
 #include <thtk/thtk.h>
 #include "thdat.h"
 #include "thrle.h"
-#include "program.h"
 
 extern const thdat_module_t archive_th02;
 extern const thdat_module_t archive_th06;


### PR DESCRIPTION
This patch removes the unused include, to make other application ([thplayer](https://github.com/BearKidsTeam/thplayer) here) that uses thtk as 3rdparty library life easier :)