### PR TITLE
fix: option to prefer static lib, fix lib install path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,6 +81,7 @@ endif()
 set(CMAKE_INSTALL_RPATH ${CMAKE_INSTALL_PREFIX}/lib)
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 
+option(BUILD_SHARED_LIBS "Prefer to build shared lib" ON)
 option(WITH_LIBPNG_SOURCE "Compile libpng from source" ON)
 option(WITH_OPENMP "Compile with OpenMP" ON)
 if(UNIX)

--- a/thtk/CMakeLists.txt
+++ b/thtk/CMakeLists.txt
@@ -1,5 +1,5 @@
 include_directories(${CMAKE_SOURCE_DIR})
-add_library(thtk SHARED
+add_library(thtk
   bits.c error.c io.c
   bits.h error.h io.h
 
@@ -29,5 +29,7 @@ endif()
 set_property(TARGET thtk PROPERTY VERSION "1.0.0")
 set_property(TARGET thtk PROPERTY SOVERSION 1)
 set_property(TARGET thtk PROPERTY C_VISIBILITY_PRESET hidden)
-install(TARGETS thtk DESTINATION lib)
+install(TARGETS thtk
+  ARCHIVE DESTINATION lib
+  RUNTIME DESTINATION bin)
 install(FILES thtk.h error.h io.h dat.h detect.h thcrypt.h thlzss.h DESTINATION include/thtk)


### PR DESCRIPTION
We are using thtk as a submodule in our project and prefer to use thtk as static library, but found it currently hard-coded to add as a shared library, and the shared library will also be installed to a incorrect location.

This patch adds an option to let developer choose the library type they want via the standard CMake option `BUILD_SHARED_LIBS`, and also make use of the `ARCHIVE`(for static lib) and `RUNTIME`(for shared lib) type in `install()` to ensure the shared lib and static lib can install to correct location.