### PR TITLE
thtk: fix pkg-config file

### DIFF
--- a/thtk/thtk.pc.in
+++ b/thtk/thtk.pc.in
@@ -1,11 +1,11 @@
 prefix = @CMAKE_INSTALL_PREFIX@
-exec_prefix = {prefix}
-includedir = {prefix}/@CMAKE_INSTALL_INCLUDEDIR@
-libdir = {exec_prefix}/@CMAKE_INSTALL_LIBDIR@
+exec_prefix = ${prefix}
+includedir = ${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+libdir = ${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
 
 Name: @PROJECT_NAME@
 Description: Touhou Toolkit shared library
 URL: @PROJECT_URL@
 Version: @PROJECT_VERSION@
-Libs: -L{libdir} -lthtk
-Cflags: -I{includedir}
+Libs: -L${libdir} -lthtk
+Cflags: -I${includedir}


### PR DESCRIPTION
According to https://people.freedesktop.org/~dbn/pkg-config-guide.html, the file `thtk/thtk.pc.in` has the wrong syntax.