### PR TITLE
Fix ECL sqrt in TH13+

### DIFF
--- a/thecl/thecl10.c
+++ b/thecl/thecl10.c
@@ -723,7 +723,6 @@ static const id_format_pair_t th13_fmts[] = {
     { 85, "fff" },
     { 86, "fff" },
     { 87, "fffff" },
-    { 88, "fffff" },
     { 89, "fff" },
     { 90, "fffff" },
     { 91, "SfSSff" },


### PR DESCRIPTION
`stackSqrt()` shouldn't take any non-stack arguments.