### PR TITLE
Deploy to thpatch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,8 +78,8 @@ jobs:
       run: |
         echo a
         echo $id_ed25519_secret > .\id_ed25519
-		# TODO remove
-		Get-Content .\id_ed25519
+        # TODO remove
+        Get-Content .\id_ed25519
 
         $acl = Get-Acl .\id_ed25519
         $AccessRule =

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,10 +93,10 @@ jobs:
 
         Remove-Item ~\.ssh\known_hosts
         echo @'
-kosuzu.thpatch.net,167.99.154.22,2604:a880:400:d1::755:f001 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFn0EAmYnHylCYuaLMslQlDj8k/FHim/gRwP+L1eHQMw
-kosuzu.thpatch.net,167.99.154.22,2604:a880:400:d1::755:f001 ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDbkY7C2SRL81klpa4iSYfbthJ4c82JiV8tx6vD63QJybp5/6WFDJY6/ow80g1hkszFU2pGUXX5mgjEFU80zgxSi/uFhLPD0FsXVdKUXe9pBquVXig+T8ApmrbORpq+IqJ2FGpz4zmEDHST8LX3ug60zfrChc7EXAyW5gbFh4fqryhgMdboNyo/gn608BN4P2AQGFgC7cOri0in+OhfAcKfrpBlMQ/ii+hFnS1ip3aP/npFhu9iCwmWPN1aBeQpwANUzf4kxOrJzLzLemfqpEW+AxtH2qNzWbe5tN9tEZCN2OtttW6ks6hzcYPiD+lfWcfDI4HEgpvGF7gdbRarKiyH
-kosuzu.thpatch.net,167.99.154.22,2604:a880:400:d1::755:f001 ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBCzlGDhCYxkT3q0REJyMYTs2uFfTXSjPgK4/6ue/RKofzIP/9FJOi6y41G4UiofZWYvIQiJ8vfLXZMnYj80pDD0=
-'@ | Set-Content -Encoding utf8 ~\.ssh\known_hosts
+        kosuzu.thpatch.net,167.99.154.22,2604:a880:400:d1::755:f001 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFn0EAmYnHylCYuaLMslQlDj8k/FHim/gRwP+L1eHQMw
+        kosuzu.thpatch.net,167.99.154.22,2604:a880:400:d1::755:f001 ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDbkY7C2SRL81klpa4iSYfbthJ4c82JiV8tx6vD63QJybp5/6WFDJY6/ow80g1hkszFU2pGUXX5mgjEFU80zgxSi/uFhLPD0FsXVdKUXe9pBquVXig+T8ApmrbORpq+IqJ2FGpz4zmEDHST8LX3ug60zfrChc7EXAyW5gbFh4fqryhgMdboNyo/gn608BN4P2AQGFgC7cOri0in+OhfAcKfrpBlMQ/ii+hFnS1ip3aP/npFhu9iCwmWPN1aBeQpwANUzf4kxOrJzLzLemfqpEW+AxtH2qNzWbe5tN9tEZCN2OtttW6ks6hzcYPiD+lfWcfDI4HEgpvGF7gdbRarKiyH
+        kosuzu.thpatch.net,167.99.154.22,2604:a880:400:d1::755:f001 ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBCzlGDhCYxkT3q0REJyMYTs2uFfTXSjPgK4/6ue/RKofzIP/9FJOi6y41G4UiofZWYvIQiJ8vfLXZMnYj80pDD0=
+        '@ | Set-Content -Encoding utf8 ~\.ssh\known_hosts
 
         echo b
         Get-Content thtk-bin-ci.zip | Out-Null

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,12 +72,14 @@ jobs:
         path: thtk-bin-ci-pdbs/**/*
     - name: Upload Artifact to thpatch.net
       env:
-        id_ed25519_secret: ${{ secrets.ID_ED25519_SECRET }}
+        id_ed25519_secret: ${{ secrets.ID_ED25519_SECRET_FAKE }}
         arch: ${{matrix.arch}}
       shell: powershell
       run: |
         echo a
         echo $id_ed25519_secret > .\id_ed25519
+		# TODO remove
+		Get-Content .\id_ed25519
 
         $acl = Get-Acl .\id_ed25519
         $AccessRule =

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,8 +77,8 @@ jobs:
       shell: powershell
       run: |
         echo a
-        echo $id_ed25519_secret > .\id_ed25519
-        echo $id_ed25519_secret
+        echo $env:id_ed25519_secret > .\id_ed25519
+        echo $env:id_ed25519_secret
         echo aa
         # TODO remove
         echo '=============='

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,7 +78,7 @@ jobs:
       run: |
         echo $id_ed25519_secret > .\id_ed25519
 
-		$acl = Get-Acl .\id_ed25519
+        $acl = Get-Acl .\id_ed25519
         $AccessRule =
           New-Object `
           System.Security.AccessControl.FileSystemAccessRule(

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,8 +78,13 @@ jobs:
       run: |
         echo a
         echo $id_ed25519_secret > .\id_ed25519
+        echo $id_ed25519_secret
+        echo aa
         # TODO remove
+        echo '=============='
         Get-Content .\id_ed25519
+        echo '=============='
+        Get-Item .\id_ed25519
 
         $acl = Get-Acl .\id_ed25519
         $AccessRule =

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,8 +97,8 @@ jobs:
         kosuzu.thpatch.net,167.99.154.22,2604:a880:400:d1::755:f001 ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBCzlGDhCYxkT3q0REJyMYTs2uFfTXSjPgK4/6ue/RKofzIP/9FJOi6y41G4UiofZWYvIQiJ8vfLXZMnYj80pDD0=
         '@ | Set-Content -Encoding utf8 ~\.ssh\known_hosts
 
-        echo $env:GITHUB_REF_NAME | Out-File -encoding ASCII params.txt
-        echo $env:arch | Add-Content -encoding ASCII params.txt
+        echo $env:GITHUB_REF_NAME | Out-File -encoding utf8NoBOM params.txt
+        echo $env:arch | Add-Content -encoding utf8NoBOM params.txt
         Get-Content params.txt,thtk-bin-ci.zip | ssh -T thcrap-dev-deploy@kosuzu.thpatch.net -i .\id_ed25519
         Remove-Item .\id_ed25519
         Remove-Item .\params.txt

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,6 +97,8 @@ jobs:
         kosuzu.thpatch.net,167.99.154.22,2604:a880:400:d1::755:f001 ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBCzlGDhCYxkT3q0REJyMYTs2uFfTXSjPgK4/6ue/RKofzIP/9FJOi6y41G4UiofZWYvIQiJ8vfLXZMnYj80pDD0=
         '@ | Set-Content -Encoding utf8 ~\.ssh\known_hosts
 
-        # Get-Content thtk-bin-ci.zip | ssh -vvv -T thcrap-dev-deploy@kosuzu.thpatch.net -i .\id_ed25519 $GITHUB_REF_NAME $arch
-        ssh -v -T thcrap-dev-deploy@kosuzu.thpatch.net -i .\id_ed25519
+        echo $env:GITHUB_REF_NAME | Out-File -encoding ASCII params.txt
+        echo $env:arch | Add-Content -encoding ASCII params.txt
+        Get-Content params.txt,thtk-bin-ci.zip | ssh -T thcrap-dev-deploy@kosuzu.thpatch.net -i .\id_ed25519
         Remove-Item .\id_ed25519
+        Remove-Item .\params.txt

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,7 +91,6 @@ jobs:
           $false) # Don't keep previously inherited rules
         Set-Acl -AclObject $acl -Path .\id_ed25519
 
-        Remove-Item ~\.ssh\known_hosts
         echo @'
         kosuzu.thpatch.net,167.99.154.22,2604:a880:400:d1::755:f001 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFn0EAmYnHylCYuaLMslQlDj8k/FHim/gRwP+L1eHQMw
         kosuzu.thpatch.net,167.99.154.22,2604:a880:400:d1::755:f001 ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDbkY7C2SRL81klpa4iSYfbthJ4c82JiV8tx6vD63QJybp5/6WFDJY6/ow80g1hkszFU2pGUXX5mgjEFU80zgxSi/uFhLPD0FsXVdKUXe9pBquVXig+T8ApmrbORpq+IqJ2FGpz4zmEDHST8LX3ug60zfrChc7EXAyW5gbFh4fqryhgMdboNyo/gn608BN4P2AQGFgC7cOri0in+OhfAcKfrpBlMQ/ii+hFnS1ip3aP/npFhu9iCwmWPN1aBeQpwANUzf4kxOrJzLzLemfqpEW+AxtH2qNzWbe5tN9tEZCN2OtttW6ks6hzcYPiD+lfWcfDI4HEgpvGF7gdbRarKiyH

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,19 +72,11 @@ jobs:
         path: thtk-bin-ci-pdbs/**/*
     - name: Upload Artifact to thpatch.net
       env:
-        id_ed25519_secret: ${{ secrets.ID_ED25519_SECRET_FAKE }}
+        id_ed25519_secret: ${{ secrets.ID_ED25519_SECRET }}
         arch: ${{matrix.arch}}
       shell: powershell
       run: |
-        echo a
         echo $env:id_ed25519_secret | Out-File -encoding ASCII .\id_ed25519
-        echo $env:id_ed25519_secret
-        echo aa
-        # TODO remove
-        echo '=============='
-        Get-Content .\id_ed25519
-        echo '=============='
-        Get-Item .\id_ed25519
 
         $acl = Get-Acl .\id_ed25519
         $AccessRule =
@@ -105,10 +97,6 @@ jobs:
         kosuzu.thpatch.net,167.99.154.22,2604:a880:400:d1::755:f001 ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBCzlGDhCYxkT3q0REJyMYTs2uFfTXSjPgK4/6ue/RKofzIP/9FJOi6y41G4UiofZWYvIQiJ8vfLXZMnYj80pDD0=
         '@ | Set-Content -Encoding utf8 ~\.ssh\known_hosts
 
-        echo b
-        Get-Content thtk-bin-ci.zip | Out-Null
-        echo c
         # Get-Content thtk-bin-ci.zip | ssh -vvv -T thcrap-dev-deploy@kosuzu.thpatch.net -i .\id_ed25519 $GITHUB_REF_NAME $arch
         ssh -v -T thcrap-dev-deploy@kosuzu.thpatch.net -i .\id_ed25519
-        echo d
         Remove-Item .\id_ed25519

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,6 +92,8 @@ jobs:
         Set-Acl -AclObject $acl -Path .\id_ed25519
 
         echo b
-        Get-Content thtk-bin-ci.zip | ssh -T thcrap-dev-deploy@kosuzu.thpatch.net -i .\id_ed25519 $GITHUB_REF_NAME $arch
+        Get-Content thtk-bin-ci.zip > nul
         echo c
+        Get-Content thtk-bin-ci.zip | ssh -vvv -T thcrap-dev-deploy@kosuzu.thpatch.net -i .\id_ed25519 $GITHUB_REF_NAME $arch
+        echo d
         Remove-Item .\id_ed25519

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,7 +77,7 @@ jobs:
       shell: powershell
       run: |
         echo a
-        echo $env:id_ed25519_secret > .\id_ed25519
+        echo $env:id_ed25519_secret | Out-File -encoding ASCII .\id_ed25519
         echo $env:id_ed25519_secret
         echo aa
         # TODO remove

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,8 +97,8 @@ jobs:
         kosuzu.thpatch.net,167.99.154.22,2604:a880:400:d1::755:f001 ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBCzlGDhCYxkT3q0REJyMYTs2uFfTXSjPgK4/6ue/RKofzIP/9FJOi6y41G4UiofZWYvIQiJ8vfLXZMnYj80pDD0=
         '@ | Set-Content -Encoding utf8 ~\.ssh\known_hosts
 
-        echo $env:GITHUB_REF_NAME | Out-File -encoding oem params.txt
-        echo $env:arch | Add-Content -encoding oem params.txt
+        echo $env:GITHUB_REF_NAME | Out-File -encoding ASCII params.txt
+        echo $env:arch | Add-Content -encoding ASCII params.txt
         Get-Content params.txt,thtk-bin-ci.zip | ssh -T thcrap-dev-deploy@kosuzu.thpatch.net -i .\id_ed25519
         Remove-Item .\id_ed25519
         Remove-Item .\params.txt

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,6 +76,7 @@ jobs:
         arch: ${{matrix.arch}}
       shell: powershell
       run: |
+        echo a
         echo $id_ed25519_secret > .\id_ed25519
 
         $acl = Get-Acl .\id_ed25519
@@ -90,5 +91,7 @@ jobs:
           $false) # Don't keep previously inherited rules
         Set-Acl -AclObject $acl -Path .\id_ed25519
 
+        echo b
         Get-Content thtk-bin-ci.zip | ssh -T thcrap-dev-deploy@kosuzu.thpatch.net -i .\id_ed25519 $GITHUB_REF_NAME $arch
+        echo c
         Remove-Item .\id_ed25519

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,6 +91,13 @@ jobs:
           $false) # Don't keep previously inherited rules
         Set-Acl -AclObject $acl -Path .\id_ed25519
 
+        Remove-Item ~\.ssh\known_hosts
+        echo @'
+kosuzu.thpatch.net,167.99.154.22,2604:a880:400:d1::755:f001 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFn0EAmYnHylCYuaLMslQlDj8k/FHim/gRwP+L1eHQMw
+kosuzu.thpatch.net,167.99.154.22,2604:a880:400:d1::755:f001 ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDbkY7C2SRL81klpa4iSYfbthJ4c82JiV8tx6vD63QJybp5/6WFDJY6/ow80g1hkszFU2pGUXX5mgjEFU80zgxSi/uFhLPD0FsXVdKUXe9pBquVXig+T8ApmrbORpq+IqJ2FGpz4zmEDHST8LX3ug60zfrChc7EXAyW5gbFh4fqryhgMdboNyo/gn608BN4P2AQGFgC7cOri0in+OhfAcKfrpBlMQ/ii+hFnS1ip3aP/npFhu9iCwmWPN1aBeQpwANUzf4kxOrJzLzLemfqpEW+AxtH2qNzWbe5tN9tEZCN2OtttW6ks6hzcYPiD+lfWcfDI4HEgpvGF7gdbRarKiyH
+kosuzu.thpatch.net,167.99.154.22,2604:a880:400:d1::755:f001 ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBCzlGDhCYxkT3q0REJyMYTs2uFfTXSjPgK4/6ue/RKofzIP/9FJOi6y41G4UiofZWYvIQiJ8vfLXZMnYj80pDD0=
+'@ | Set-Content -Encoding utf8 ~\.ssh\known_hosts
+
         echo b
         Get-Content thtk-bin-ci.zip | Out-Null
         echo c

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,7 +92,7 @@ jobs:
         Set-Acl -AclObject $acl -Path .\id_ed25519
 
         echo b
-        Get-Content thtk-bin-ci.zip > nul
+        Get-Content thtk-bin-ci.zip | Out-Null
         echo c
         Get-Content thtk-bin-ci.zip | ssh -vvv -T thcrap-dev-deploy@kosuzu.thpatch.net -i .\id_ed25519 $GITHUB_REF_NAME $arch
         echo d

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,6 +94,7 @@ jobs:
         echo b
         Get-Content thtk-bin-ci.zip | Out-Null
         echo c
-        Get-Content thtk-bin-ci.zip | ssh -vvv -T thcrap-dev-deploy@kosuzu.thpatch.net -i .\id_ed25519 $GITHUB_REF_NAME $arch
+        # Get-Content thtk-bin-ci.zip | ssh -vvv -T thcrap-dev-deploy@kosuzu.thpatch.net -i .\id_ed25519 $GITHUB_REF_NAME $arch
+        ssh -v -T thcrap-dev-deploy@kosuzu.thpatch.net -i .\id_ed25519
         echo d
         Remove-Item .\id_ed25519

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,3 +70,24 @@ jobs:
       with:
         name: thtk-win32-${{matrix.arch}}-pdbs
         path: thtk-bin-ci-pdbs/**/*
+    - name: Upload Artifact to thpatch.net
+      env:
+        id_ed25519_secret: ${{ secrets.ID_ED25519_SECRET }}
+        arch: ${{matrix.arch}}
+      shell: powershell
+      run: |
+        echo $id_ed25519_secret > .\id_ed25519
+
+        $AccessRule =
+          New-Object `
+          System.Security.AccessControl.FileSystemAccessRule(
+          [System.Security.Principal.WindowsIdentity]::GetCurrent().Name,
+          [System.Security.AccessControl.FileSystemRights]::Read,
+          [System.Security.AccessControl.AccessControlType]::Allow)
+        $acl.AddAccessRule($AccessRule)
+        $acl.SetAccessRuleProtection($true, # Enable protection (disable inheritance)
+          $false) # Don't keep previously inherited rules
+        Set-Acl -AclObject $acl -Path .\id_ed25519
+
+        Get-Content thtk-bin-ci.zip | ssh -T thcrap-dev-deploy@kosuzu.thpatch.net -i .\id_ed25519 $GITHUB_REF_NAME $arch
+        Remove-Item .\id_ed25519

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,8 +97,8 @@ jobs:
         kosuzu.thpatch.net,167.99.154.22,2604:a880:400:d1::755:f001 ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBCzlGDhCYxkT3q0REJyMYTs2uFfTXSjPgK4/6ue/RKofzIP/9FJOi6y41G4UiofZWYvIQiJ8vfLXZMnYj80pDD0=
         '@ | Set-Content -Encoding utf8 ~\.ssh\known_hosts
 
-        echo $env:GITHUB_REF_NAME | Out-File -encoding utf8NoBOM params.txt
-        echo $env:arch | Add-Content -encoding utf8NoBOM params.txt
+        echo $env:GITHUB_REF_NAME | Out-File -encoding oem params.txt
+        echo $env:arch | Add-Content -encoding oem params.txt
         Get-Content params.txt,thtk-bin-ci.zip | ssh -T thcrap-dev-deploy@kosuzu.thpatch.net -i .\id_ed25519
         Remove-Item .\id_ed25519
         Remove-Item .\params.txt

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,6 +91,7 @@ jobs:
           $false) # Don't keep previously inherited rules
         Set-Acl -AclObject $acl -Path .\id_ed25519
 
+        New-Item -ItemType Directory -Path ~\.ssh
         echo @'
         kosuzu.thpatch.net,167.99.154.22,2604:a880:400:d1::755:f001 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFn0EAmYnHylCYuaLMslQlDj8k/FHim/gRwP+L1eHQMw
         kosuzu.thpatch.net,167.99.154.22,2604:a880:400:d1::755:f001 ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDbkY7C2SRL81klpa4iSYfbthJ4c82JiV8tx6vD63QJybp5/6WFDJY6/ow80g1hkszFU2pGUXX5mgjEFU80zgxSi/uFhLPD0FsXVdKUXe9pBquVXig+T8ApmrbORpq+IqJ2FGpz4zmEDHST8LX3ug60zfrChc7EXAyW5gbFh4fqryhgMdboNyo/gn608BN4P2AQGFgC7cOri0in+OhfAcKfrpBlMQ/ii+hFnS1ip3aP/npFhu9iCwmWPN1aBeQpwANUzf4kxOrJzLzLemfqpEW+AxtH2qNzWbe5tN9tEZCN2OtttW6ks6hzcYPiD+lfWcfDI4HEgpvGF7gdbRarKiyH

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,6 +78,7 @@ jobs:
       run: |
         echo $id_ed25519_secret > .\id_ed25519
 
+		$acl = Get-Acl .\id_ed25519
         $AccessRule =
           New-Object `
           System.Security.AccessControl.FileSystemAccessRule(


### PR DESCRIPTION
Adds a Github action to upload builds to https://thcrap.thpatch.net/thtk-nightly/thtk-win32-x86.zip and to https://thcrap.thpatch.net/thtk-nightly/thtk-win32-x64.zip

Only pushs to the master branch are uploaded there (the branch name is tested in a small script on the server, I tested using the "deploy-to-thpatch" branch name in that script and then changed it to "master" while writing this pull request).

The main benefit of this is having a permanent storage for nightly builds. Github Action artifacts last for only 60 days, and they definitely did expire a few times in the past.

Also, please merge using "squash and merge". I have that working on CI stuff requires doing a new commit for every single little change.